### PR TITLE
v1.4.1 — docs sync to v1.4.0 surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [1.4.1] — Docs sync to v1.4.0 surfaces (2026-06-04)
+
+PATCH release. Docs-only — no code or behaviour change. Closes the gap
+between the v1.4.0 release notes and what user-facing docs actually say,
+so a fresh reader landing on README / RESEARCHER_GUIDE / USE_CASES sees
+the literature loop + language doctrine documented, not just mentioned in
+CHANGELOG.
+
+### Fixed
+
+- **Count refs across 8 docs.** `110 protocols` → `113 protocols`,
+  `149 MCP tools` → `146 MCP tools` in README.md, FAQ.md, PROTOCOLS.md,
+  START.md, AI_GUIDE.md, RESEARCHER_GUIDE.md, TOOLS.md, CONTRIBUTING.md.
+- **PROTOCOLS.md category table.** Updated stale per-category counts
+  (methodology 29 → 42, synthesis 14 → 17, visualization 6 → 14,
+  literature 4 → 5) and total (88 → 113). Added inline v1.4.0 callouts
+  per category.
+- **TOOLS.md audit section.** Added `tool_audit_step_completeness`
+  + new `tool_audit_step_literature` entries with v1.4.0 behaviour
+  notes (BLOCK on missing `.summary.md`, WARN on missing
+  `stack_plan.md`, BLOCK on missing `findings_vs_literature.md`).
+- **RESEARCHER_GUIDE.md.** Surface `literature_per_step`,
+  `pick_tool_stack`, and `mixed_language_orchestration` in the
+  category inventory with one-line descriptions.
+- **AI_GUIDE.md.** Category table now flags which categories grew
+  in v1.4.0 + names the new protocols.
+- **USE_CASES.md.** New "What's new in v1.4.0" section + 3 new
+  rows in the "By output type" table (literature_per_step,
+  pick_tool_stack, mixed_language_orchestration).
+
+### Validation
+
+- preflight 14/14, pytest 492 passed, ruff clean — no functional
+  changes; tests run for safety only.
+- All count references now reflect the authoritative counts from
+  `len(TOOL_DEFINITIONS)` (146) and the protocol YAML inventory (113).
+
+### Migration
+
+None — docs-only release.
+
+---
+
 ## [1.4.0] — Literature loop + language/tool-stack doctrine + summary fill-rate fix (2026-06-04)
 
 Rolls v1.3.4 fixes + four new pillars driven by user feedback after the 22-turn stress test:

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,6 @@ authors:
 - family-names: "Setlur"
   given-names: "Vibhav"
 title: "Research OS"
-version: 1.4.0
+version: 1.4.1
 date-released: 2026-06-04
 url: "https://github.com/VibhavSetlur/Research-OS"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ contribute changes that keep the surface small and the protocols sharp.
 
 The AI IDE is the brain (Cursor / Claude Code / Claude Desktop /
 OpenCode / Antigravity / VS Code / Windsurf / Continue / Aider).
-Research OS is the body: 149 MCP tools and 110 YAML protocols, plus a
+Research OS is the body: 146 MCP tools and 113 YAML protocols, plus a
 **hybrid semantic + trigger router** that turns a user prompt into a
 protocol pick + planned tool sequence without the AI ever loading the
 trigger index itself. The semantic path uses local BGE-small ONNX

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -81,19 +81,19 @@ the working set for a protocol, call `sys_active_tools(protocol_name)`.
 
 ---
 
-## Protocol categories (110 protocols, organised in 9)
+## Protocol categories (113 protocols, organised in 9)
 
 | Category | What it covers |
 |---|---|
 | guidance | session + flow control (boot / resume / handoff / autopilot / casual / mid_entry / disagree / scope_clarification / revise) |
 | discover | intake + question lock-in + scope_clarification |
 | domain | domain classification + study design |
-| methodology | method picking + per-method protocols (29 protocols) |
-| literature | search + systematic review + evidence synthesis + comparative review |
+| methodology | method picking + per-method protocols (42 protocols, incl. **v1.4.0** `pick_tool_stack` + `mixed_language_orchestration`) |
+| literature | search + systematic review + evidence synthesis + comparative review + **v1.4.0** `literature_per_step` (per-step findings_vs_literature.md loop) |
 | writing | per-section drafting (methods / results / discussion / limitations / end_matter) |
-| visualization | figures (rules / workflow / critique / multi-panel / arc / a11y) |
-| synthesis | final deliverables (14 protocols: paper / abstract / poster / dashboard / slides / lay / handout / report / grant / progress / from_inputs / null / cover_letter / title) |
-| audit + reproducibility | quality audit + pre-submission checklist + provenance completeness + repro audit |
+| visualization | figures (rules / workflow / critique / multi-panel / arc / a11y / interactive) |
+| synthesis | final deliverables (17 protocols: paper / abstract / poster / dashboard / slides / lay / handout / report / grant / progress / from_inputs / null / cover_letter / title) |
+| audit + reproducibility | quality audit + pre-submission checklist + provenance completeness + repro audit + **v1.4.0** `tool_audit_step_literature` gate |
 
 For a category-specific orientation, call `sys_help(topic="<category>")`.
 Useful operational topics that aren't categories:
@@ -333,5 +333,5 @@ server enforces DPI, sidecars, palette via `tool_audit_figure_full` and
 - `sys_help(topic="synthesis")` → category-specific guidance
 - `sys_active_project` → which project is this request operating on
 - `tool_route(prompt)` → re-route on a new researcher message
-- `sys_protocol_list` → all 110 protocols indexed
+- `sys_protocol_list` → all 113 protocols indexed
 - `sys_tool_describe(tool_name)` → full schema for a tool

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -58,7 +58,7 @@ endpoints (Crossref, PubMed, arXiv) automatically and only enables the
 paid / rate-limited search backend when its key is present. No restart
 needed — the server re-reads the file each session.
 
-### Do I have to read all 110 protocols to know which to use?
+### Do I have to read all 113 protocols to know which to use?
 
 No. You never browse protocols. You speak in plain English; `tool_route`
 maps your message to the right protocol. As of v1.2.0 it tries

--- a/docs/PROTOCOLS.md
+++ b/docs/PROTOCOLS.md
@@ -1,6 +1,6 @@
 # Protocol Reference
 
-Research OS ships **110 YAML protocols** organised into nine categories.
+Research OS ships **113 YAML protocols** organised into nine categories.
 Each protocol is a sequence of steps the AI should follow, with explicit
 `expected_outputs`, a `next_protocol` pointer, and a `quality_bar`. All
 are indexed in `src/research_os/protocols/_router_index.yaml` for
@@ -8,16 +8,16 @@ hierarchical routing via `tool_route`.
 
 | Category | Count | What's in it |
 |---|---|---|
-| `methodology/` | 29 | Method pickers + per-family deep workflows (causal, ML, Bayesian, time-series, clinical, qualitative, mixed-methods, simulation, replication, ablation, pilot, evaluation design, hyperparameter sweep design, ethics review, EDA + hypothesis generation, method comparison, data-quality audit, power analysis, reproduction, methodological consultation). |
+| `methodology/` | 42 | Method pickers + per-family deep workflows (causal, ML, Bayesian, time-series, clinical, qualitative, mixed-methods, simulation, replication, ablation, pilot, evaluation design, hyperparameter sweep design, ethics review, EDA + hypothesis generation, method comparison, data-quality audit, power analysis, reproduction, methodological consultation). **v1.4.0** adds `pick_tool_stack` (R vs Python per sub-task, field-practice grounded) and `mixed_language_orchestration` (Python↔R↔Bash composition doctrine). |
 | `guidance/` | 19 | Session boot / resume / handoff / autopilot / collaboration, intake, iterative planning, dead-end routing, hypothesis + glossary tracking, mid-pipeline entry, code review, peer-review response, **scope-clarification**. |
-| `synthesis/` | 14 | Paper, abstract, poster, dashboard, grant, report, slides, lay summary, progress update, cover letter, title workshop, handout, null-findings companion, synthesis-from-inputs. |
+| `synthesis/` | 17 | Paper, abstract, poster, dashboard, grant, report, slides, lay summary, progress update, cover letter, title workshop, handout, null-findings companion, synthesis-from-inputs. |
+| `visualization/` | 14 | Figure guidelines, viz workflow, single-figure critique, multi-panel composition, narrative arc, colour-accessibility audit, interactive figure design. |
 | `writing/` | 10 | Per-section drafting (methods / results / discussion / limitations / end-matter), writing core rules, citations ledger, conclusions, analysis log, README. |
-| `visualization/` | 6 | Figure guidelines, viz workflow, single-figure critique, multi-panel composition, narrative arc, colour-accessibility audit. |
-| `literature/` | 4 | Search, systematic review (PRISMA), evidence synthesis (GRADE), comparative paper review. |
-| `audit/` | 3 | Master audit + validation, plus targeted gates. |
+| `literature/` | 5 | Search, systematic review (PRISMA), evidence synthesis (GRADE), comparative paper review. **v1.4.0** adds `literature_per_step` — per-step search → download → cite → write `findings_vs_literature.md` (AGREES \| DISAGREES \| EXTENDS \| DEFERRED). |
+| `audit/` | 3 | Master audit + validation, pre-submission checklist, provenance completeness. |
 | `domain/` | 2 | Domain classification, research-design + sample-size justification. |
 | `reproducibility/` | 1 | Per-step env lock, seed verification, container generation. |
-| **Total** | **88** | |
+| **Total** | **113** | |
 
 The protocol surface deliberately covers BOTH the canonical
 data → publication pipeline AND the partial / off-axis workflows

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,8 +16,8 @@ Pick the doc that matches what you need.
 
 | Doc | When to read it |
 |---|---|
-| [**PROTOCOLS.md**](PROTOCOLS.md) | Catalogue of all 110 protocols — when each fires, what it does, quality bars. |
-| [**TOOLS.md**](TOOLS.md) | Catalogue of all 149 MCP tools, with example calls. |
+| [**PROTOCOLS.md**](PROTOCOLS.md) | Catalogue of all 113 protocols — when each fires, what it does, quality bars. |
+| [**TOOLS.md**](TOOLS.md) | Catalogue of all 146 MCP tools, with example calls. |
 | [**AI_GUIDE.md**](AI_GUIDE.md) | Operating manual for the AI driving Research OS. Read this when you're debugging "why did the AI do that?" — the runtime equivalent is the `sys_help` tool. |
 
 ## Contributors

--- a/docs/RESEARCHER_GUIDE.md
+++ b/docs/RESEARCHER_GUIDE.md
@@ -3,7 +3,7 @@
 The full guide to working with Research OS day-to-day. Read after
 [START.md](START.md) (5-minute install + first project). This document
 covers: the mental model, the file layout, a typical session, the
-canonical 10-stage pipeline, all 110 protocols and 149 MCP tools, the
+canonical 10-stage pipeline, all 113 protocols and 146 MCP tools, the
 config schema, power-user patterns, and troubleshooting.
 
 For the AI-driving-Research-OS guide (which the AI itself reads), see
@@ -246,7 +246,7 @@ For the full role × goal × output map, see [USE_CASES.md](USE_CASES.md).
 
 ---
 
-## 6. The on-demand protocol surface (82 total)
+## 6. The on-demand protocol surface (113 total)
 
 For per-protocol triggers + quality bars, see
 [PROTOCOLS.md](PROTOCOLS.md). High-level inventory:
@@ -259,7 +259,7 @@ For per-protocol triggers + quality bars, see
 `hypothesis_tracking` / `glossary_update` / `mid_pipeline_entry` /
 `constructive_disagreement`.
 
-**Domain + methodology (24)** — `domain_analysis` / `research_design` /
+**Domain + methodology (42)** — `domain_analysis` / `research_design` /
 `methodology_selection` / `deep_domain_research` / `preregistration` /
 `tool_discovery` + per-method: `causal_inference_deep` /
 `machine_learning` / `clinical_trials` / `meta_analysis` /
@@ -269,11 +269,21 @@ For per-protocol triggers + quality bars, see
 design / workflow: `exploratory_data_analysis` / `method_comparison` /
 `data_quality_audit` / `power_analysis` / `evaluation_design` /
 `hyperparameter_search_design` / `data_ethics_review` /
-`reproduction_attempt` / `methodological_consultation`.
+`reproduction_attempt` / `methodological_consultation` +
+**v1.4.0** language/tool-stack doctrine: **`pick_tool_stack`** (R vs
+Python per sub-task — bulk RNA-seq → R Bioconductor, scRNA-seq →
+Python scanpy, Cox PH → R survival, WGCNA → R, geospatial → Python
+geopandas, psychometrics → R psych/lavaan; persists to
+`workspace/<step>/scratch/stack_plan.md`) / **`mixed_language_orchestration`**
+(Python↔R↔Bash composition: hand-off file contracts, serialization
+matrix, per-language `pipeline.yaml` tags, schema assertions).
 
-**Literature (4)** — `literature_search` (with forward-citation walk +
+**Literature (5)** — `literature_search` (with forward-citation walk +
 predatory-venue check) / `systematic_review` / `evidence_synthesis` /
-`comparative_paper_review`.
+`comparative_paper_review` / **`literature_per_step`** (v1.4.0 —
+per-step search → download → cite → write `findings_vs_literature.md`
+with AGREES \| DISAGREES \| EXTENDS \| DEFERRED verdicts; gated by
+`tool_audit_step_literature` before `tool_path_finalize`).
 
 **Writing (9)** — `writing_core` (universal rules) + per-section:
 `writing_methods` / `writing_results` / `writing_discussion` /
@@ -302,7 +312,7 @@ verification).
 
 ---
 
-## 7. MCP tools (143 total)
+## 7. MCP tools (146 total)
 
 > All names use underscores. Dot notation + legacy names are
 > auto-rewritten. Full catalogue with example calls:
@@ -635,8 +645,8 @@ For more: [FAQ.md](FAQ.md).
 * [USE_CASES.md](USE_CASES.md) — role × goal × output map.
 * [SETUP.md](SETUP.md) — install + per-IDE wiring + troubleshooting.
 * [FAQ.md](FAQ.md) — common questions.
-* [PROTOCOLS.md](PROTOCOLS.md) — catalogue of all 110 protocols.
-* [TOOLS.md](TOOLS.md) — catalogue of all 149 MCP tools.
+* [PROTOCOLS.md](PROTOCOLS.md) — catalogue of all 113 protocols.
+* [TOOLS.md](TOOLS.md) — catalogue of all 146 MCP tools.
 * [AI_GUIDE.md](AI_GUIDE.md) — operating manual for the AI driving Research OS.
 * [PROTOCOL_DOCTRINE.md](PROTOCOL_DOCTRINE.md) — scaffold-not-script
   principle (for protocol authors / contributors).

--- a/docs/START.md
+++ b/docs/START.md
@@ -130,7 +130,7 @@ up. Full table in [SETUP.md § 6](SETUP.md#pick-the-right-model_profile-for-your
 * **Sub-task pipelines, not mega-scripts.** Steps with >2 scripts must
   declare a `pipeline.yaml` of atomic nodes (ingest → validate → clean
   → fit → diagnose → visualize → report). Content-hash cached.
-* **110 protocols** the AI picks from via `tool_route`. Covers the
+* **113 protocols** the AI picks from via `tool_route`. Covers the
   canonical data → publication pipeline plus partial / off-axis
   workflows (visualization-only, talks, lay summaries, EDA + hypothesis
   generation, method comparison, reproduction, methodological
@@ -138,7 +138,7 @@ up. Full table in [SETUP.md § 6](SETUP.md#pick-the-right-model_profile-for-your
   qualitative + survey design, IRR, fairness, calibrated UQ,
   manuscript outline, venue selection, defense prep, and Data
   Management Plans).
-* **149 MCP tools** across three namespaces — `sys_*` (system /
+* **146 MCP tools** across three namespaces — `sys_*` (system /
   workspace / files / state), `tool_*` (research work), `mem_*`
   (append-only memory).
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # Tool Catalog
 
-**149 MCP tools** across three namespaces (`sys_*` / `tool_*` / `mem_*`).
+**146 MCP tools** across three namespaces (`sys_*` / `tool_*` / `mem_*`).
 Names use underscores; dot notation (`sys.state.get`) and a small set
 of legacy aliases (e.g. `tool_audit_statistical_power` →
 `tool_audit_power`) auto-rewrite. `sys_tool_describe(name)` returns the
@@ -128,7 +128,9 @@ the router picks one for you.
 
 | Tool | Purpose |
 |---|---|
-| `tool_audit_synthesis` | Audit a manuscript: claim grounding, citation coverage, causal language. |
+| `tool_audit_synthesis` | Audit a manuscript: claim grounding, citation coverage, causal language. v1.3.4+ aggregates per-step `step_summary.yaml` warnings and BLOCKs on pending-verification citations; v1.4.0+ BLOCKs on per-step `literature_deferred` + `literature.claims_grounded == 0`. |
+| `tool_audit_step_completeness` | Per-step gate: focal figure + caption + summary sidecars + non-stub conclusions + no mega-script. v1.4.0+ BLOCKs on missing `.summary.md` (was WARN) + WARNs on missing `scratch/stack_plan.md`. |
+| `tool_audit_step_literature` | **v1.4.0.** Per-step literature-loop gate. BLOCKs if `workspace/<step>/literature/findings_vs_literature.md` missing, any claim lacks a Verdict (AGREES \| DISAGREES \| EXTENDS \| DEFERRED), any DISAGREES verdict lacks a Discussion implication block, all-DEFERRED with no PDFs, or stub `## Findings`. Override: `override_literature_gate=true` + rationale. Writes `workspace/logs/step_literature_audit.md`. |
 | `tool_audit_power` | Post-hoc statistical power. |
 | `tool_audit_assumptions` | Normality + homoscedasticity + independence on residuals. |
 | `tool_audit_figure` | DPI / colorblind palette / axis labels / error bars. |

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -203,6 +203,51 @@ don't want to redo the intake.
 | Data ethics review document | `methodology/data_ethics_review` |
 | Data-quality audit report | `methodology/data_quality_audit` |
 | Methodological consultation notes (optional) | `methodology/methodological_consultation` |
+| Per-step literature grounding (`findings_vs_literature.md`) | `literature/literature_per_step` *(v1.4.0)* |
+| Language / tool-stack decision (R vs Python per sub-task) | `methodology/pick_tool_stack` *(v1.4.0)* |
+| Mixed-language step (Python ↔ R ↔ Bash composition) | `methodology/mixed_language_orchestration` *(v1.4.0)* |
+
+---
+
+## What's new in v1.4.0
+
+- **Per-step literature loop** — after every analysis step writes
+  `## Findings` in `conclusions.md`, the AI now searches Semantic
+  Scholar / PubMed / Crossref per claim, downloads top PDFs into
+  `workspace/<step>/literature/`, and writes
+  `findings_vs_literature.md` with a `## Claim:` block per finding
+  (AGREES | DISAGREES | EXTENDS | DEFERRED + Evidence +
+  Discussion implication). `tool_audit_step_literature` BLOCKS
+  `tool_path_finalize` if missing or DISAGREES has no discussion.
+  Trigger: *"ground this step"*, *"compare to literature"*, *"is
+  this novel"*, or invoked automatically from
+  `analysis_plan.ground_findings_in_literature`.
+- **Language + tool-stack doctrine** — RO no longer defaults to
+  Python out of habit. `pick_tool_stack` enumerates language
+  candidates per sub-task, queries field practice (R Bioconductor
+  for bulk DE, Python scanpy for scRNA-seq, R survival for Cox PH,
+  WGCNA → R, geopandas → Python, …), and persists the choice + the
+  citation that grounds it to
+  `workspace/<step>/scratch/stack_plan.md`. Audit warns when this
+  artefact is missing.
+- **Mixed-language steps** — Python ↔ R ↔ Bash composition is now a
+  first-class protocol (`mixed_language_orchestration`) with
+  hand-off file contracts, serialization matrix (TSV / Parquet /
+  .mtx / RDS — never cross-language pickle), per-language
+  `pipeline.yaml` tags, and schema assertions at consumer entry.
+- **Summary fill-rate fix** — `tool_figure_caption_synthesise` now
+  pulls a "Why it matters" sentence from prose `## Findings`
+  sections (no longer requires bullets); missing `.summary.md`
+  sidecars now BLOCK at audit (were WARN).
+- **9 grounding tools wired into protocols** — `thought_log`,
+  `thought_trace`, `grounding_register`, `ground_from_context`,
+  `claim_verify`, `grounding_verify`, `lessons_record`,
+  `lessons_consult`, `plan_step_grounded` were orphan in v1.3.x;
+  now invoked from `project_startup`, `analysis_plan`,
+  `literature_per_step`, `writing_core`, and
+  `pre_submission_checklist`.
+
+See [CHANGELOG.md](../CHANGELOG.md) `[1.4.0]` for the full diff.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "1.4.0"
+version = "1.4.1"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "1.4.0"
+__version__ = "1.4.1"


### PR DESCRIPTION
PATCH release. Docs-only.

- Count refs fixed across 8 docs (110→113 protocols, 149→146 tools)
- PROTOCOLS.md category table updated (methodology 29→42, etc.; total 88→113)
- TOOLS.md: new tool_audit_step_literature documented + step_completeness v1.4.0 notes
- RESEARCHER_GUIDE / AI_GUIDE / USE_CASES: literature_per_step + pick_tool_stack + mixed_language_orchestration now in user-facing inventory + new 'What's new in v1.4.0' section
- CHANGELOG [1.4.1] entry + version bump 1.4.0→1.4.1

preflight 14/14, pytest 492 passed, ruff clean. No functional changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)