### PR TITLE
Release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [1.4.2] — README PyPI badge cache-bust (2026-06-04)
+
+PATCH release. README-only — no code or behaviour change. Forces image
+proxies (GitHub `camo.githubusercontent.com` + PyPI's README image
+cache) to refresh the PyPI version badge, which was still showing
+`v1.3.3` for some viewers after v1.4.0 / v1.4.1 shipped.
+
+### Fixed
+
+- **README PyPI badge.** Added `&cacheSeconds=300` to the shields.io
+  badge URL (`img.shields.io/pypi/v/research-os.svg`). Tells shields.io
+  to refresh every 5 minutes instead of using the default longer
+  cache. The new URL also breaks GitHub's stale camo proxy cache (a
+  new src URL forces a re-proxy) and the new sdist upload regenerates
+  PyPI's rendered README. Both viewers should now see the correct
+  current version within minutes of the next release.
+- **Note on reality:** the shields.io URL itself was always returning
+  the correct version (confirmed via `curl`); only the downstream
+  image proxies were serving stale frames. There was never a packaging
+  / release-pipeline bug — purely a CDN/proxy cache issue.
+
+### Validation
+
+- No tests touched. preflight 14/14, pytest 492 passed, ruff clean.
+
+### Migration
+
+None — README-only release.
+
+---
+
 ## [1.4.1] — Docs sync to v1.4.0 surfaces (2026-06-04)
 
 PATCH release. Docs-only — no code or behaviour change. Closes the gap

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,6 @@ authors:
 - family-names: "Setlur"
   given-names: "Vibhav"
 title: "Research OS"
-version: 1.4.1
+version: 1.4.2
 date-released: 2026-06-04
 url: "https://github.com/VibhavSetlur/Research-OS"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Research OS</h1>
 
 <p align="center">
-  <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/pypi/v/research-os.svg?color=orange" alt="PyPI"></a>
+  <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/pypi/v/research-os.svg?color=orange&cacheSeconds=300" alt="PyPI"></a>
   <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg" alt="Python"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT"></a>
   <a href="https://github.com/VibhavSetlur/Research-OS/actions/workflows/test.yml"><img src="https://github.com/VibhavSetlur/Research-OS/actions/workflows/test.yml/badge.svg" alt="tests"></a>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "1.4.1"
+version = "1.4.2"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "1.4.1"
+__version__ = "1.4.2"


### PR DESCRIPTION
PATCH release. README PyPI badge cache-bust. See [CHANGELOG.md](CHANGELOG.md) [1.4.2].

- README badge URL gets `&cacheSeconds=300` query param
- Forces GitHub camo + PyPI rendered README to refresh badge image
- shields.io was always returning correct version; only downstream image proxies were stale

No behaviour change. preflight 14/14, pytest 492, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)