### PR TITLE
fix(codeql): address 4 CodeQL alerts from v1.5.0

### DIFF
--- a/src/research_os/tools/actions/search/literature.py
+++ b/src/research_os/tools/actions/search/literature.py
@@ -243,6 +243,10 @@ def download_literature(
                             permanent=True,
                         )
                     except Exception:
+                        # Best-effort logging — the cache is a
+                        # convenience, not a correctness guarantee.
+                        # Swallow any failure so the paywall response
+                        # below still reaches the caller.
                         pass
                 return {
                     "status": "error",
@@ -292,6 +296,9 @@ def download_literature(
                         permanent=permanent_flag,
                     )
                 except Exception:
+                    # Cache write is best-effort; the actual download
+                    # error below is what the caller acts on. Don't
+                    # mask the real failure with a cache-write fault.
                     pass
             return {"status": "error",
                     "message": f"Download failed: {e}"}

--- a/src/research_os/tools/actions/state/reliability.py
+++ b/src/research_os/tools/actions/state/reliability.py
@@ -201,8 +201,10 @@ def reliability_report(root: Path) -> dict[str, Any]:
 
         lines += [
             "",
-            "_Report contains no project content — only structural counts "
-            "and protocol identifiers. Safe to share when filing a bug._",
+            (
+                "_Report contains no project content — only structural counts "
+                "and protocol identifiers. Safe to share when filing a bug._"
+            ),
         ]
         report_path = root / "workspace" / "logs" / "reliability_report.md"
         report_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/tools/test_v1_5_0.py
+++ b/tests/tools/test_v1_5_0.py
@@ -15,7 +15,6 @@ Covers the surfaces introduced in v1.5.0:
 
 from __future__ import annotations
 
-import json
 import os
 import time
 from pathlib import Path


### PR DESCRIPTION
Addresses 4 CodeQL alerts surfaced on release PR #33:

- **#206** \`reliability.py:204\` — implicit string concatenation inside a list literal. Wrapped the split string in parens so it's an explicit tuple/grouping. No behaviour change.
- **#203 + #204** \`literature.py:245, 294\` — two \`except Exception: pass\` blocks (in the paywall-memory cache write path). Both now carry explanatory comments noting the cache write is best-effort and must not mask the actual download/paywall error the caller acts on.
- **#205** \`tests/tools/test_v1_5_0.py:18\` — dropped unused \`import json\`.

## Validation
- preflight 14/14
- pytest 508 pass
- ruff clean

Once merged, the four conversation threads on #33 will be resolved via GraphQL and #33 retried for merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)