### PR TITLE
v1.5.2 PATCH — fix 3 v1.5.1 stress-audit blockers that missed the release race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [1.5.2] — Fix v1.5.1 stress-audit blockers that missed the v1.5.1 race (2026-06-05)
+
+PATCH release. Ships the three critical fixes the v1.5.1 stress audit
+surfaced after the v1.5.1 release PR had already merged.
+
+### Fixed
+
+- **`templates/researcher_config.yaml`** — adds the `gate_strictness`
+  and `project_tier` fields. v1.5.1 wired these in code but missed
+  the template, which meant fresh `research-os init` users got
+  zero exposure to the new features. Adoption is now actually
+  possible.
+- **`src/research_os/tools/actions/state/certifications.py`** — a
+  transient YAML parse failure used to silently wipe the
+  certifications database (load returned an empty dict, next save
+  destroyed the audit trail). v1.5.2 distinguishes missing-file
+  from corrupted-file via a new `_CertParseError` exception and
+  refuses to save over a corrupted file. `self_certify`,
+  `list_certifications`, and `has_active_certification` all surface
+  the parse error instead of swallowing it.
+- **`src/research_os/tools/actions/state/quick_mode.py` —
+  `promote_to_step`:**
+  - **Path-traversal guard.** Refuses scratch paths that resolve
+    outside the project root (`..` or absolute paths).
+  - **Step number regex.** v1.5.1 parsed `name[:2]` to compute
+    `next_num`; projects with 100+ steps collided. v1.5.2 parses
+    the leading-digit run with `^(\d+)_` regex.
+
+### Validation
+
+- `python scripts/preflight.py` — 14/14
+- `python -m pytest -q` — 528 passed
+- `ruff check src/ tests/ scripts/` — clean
+- No tool count change; v1.5.1 surface preserved.
+
+### Why this is a separate PATCH
+
+These fixes were committed to `feat/v1.5.1` AFTER PR #37
+(feat/v1.5.1 → dev) had already squash-merged but BEFORE I could
+re-push them. The release PR (dev → main) merged on the v1.5.1
+commit that didn't include the fixes, then dev was auto-deleted on
+merge so the fix branch couldn't catch up. Standard "v1.5.0 race"
+pattern surfacing again — v1.5.2 closes it.
+
+---
+
 ## [1.5.1] — Adaptive UX: friction scales with rigor + quick mode for throwaway work (2026-06-04)
 
 MINOR release. Stops the AI from being overkill on rigorous researchers

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,6 @@ authors:
 - family-names: "Setlur"
   given-names: "Vibhav"
 title: "Research OS"
-version: 1.5.1
+version: 1.5.2
 date-released: 2026-06-04
 url: "https://github.com/VibhavSetlur/Research-OS"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "1.5.1"
+version = "1.5.2"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "1.5.1"
+__version__ = "1.5.2"

--- a/src/research_os/tools/actions/state/certifications.py
+++ b/src/research_os/tools/actions/state/certifications.py
@@ -38,19 +38,35 @@ def _cert_path(root: Path) -> Path:
     return root / "workspace" / "researcher_certifications.yaml"
 
 
+class _CertParseError(Exception):
+    """Raised when the on-disk certifications file is unparseable."""
+
+
 def _load(root: Path) -> dict[str, Any]:
+    """Read certifications. Distinguishes missing from corrupted —
+    a parse failure raises so callers don't silently wipe data on save.
+    v1.5.2 fix carried from v1.5.1 stress audit."""
     path = _cert_path(root)
     if not path.exists():
-        return {"version": "1.5.1", "certifications": []}
+        return {"version": "1.5.2", "certifications": []}
     try:
         import yaml  # type: ignore
-        data = yaml.safe_load(path.read_text()) or {}
+        text = path.read_text()
+        data = yaml.safe_load(text)
+        if data is None:
+            return {"version": "1.5.2", "certifications": []}
         if not isinstance(data, dict):
-            return {"version": "1.5.1", "certifications": []}
+            raise _CertParseError(
+                "certifications file is not a YAML mapping"
+            )
         data.setdefault("certifications", [])
         return data
-    except Exception:
-        return {"version": "1.5.1", "certifications": []}
+    except _CertParseError:
+        raise
+    except Exception as e:
+        raise _CertParseError(
+            f"certifications file exists but is unparseable: {e}"
+        ) from e
 
 
 def _save(root: Path, data: dict[str, Any]) -> None:
@@ -99,7 +115,17 @@ def self_certify(
                 "status": "error",
                 "message": "scope and rationale are required.",
             }
-        data = _load(root)
+        try:
+            data = _load(root)
+        except _CertParseError as e:
+            return {
+                "status": "error",
+                "message": (
+                    f"Refusing to overwrite a corrupted "
+                    f"researcher_certifications.yaml — {e}. Hand-edit "
+                    "or delete the file first."
+                ),
+            }
         cert = {
             "domain": "literature_loop" if domain == "lit_loop" else domain,
             "scope": scope.strip(),
@@ -121,7 +147,10 @@ def self_certify(
 def list_certifications(root: Path) -> dict[str, Any]:
     """List active certifications."""
     try:
-        data = _load(root)
+        try:
+            data = _load(root)
+        except _CertParseError as e:
+            return {"status": "error", "message": str(e)}
         return {
             "status": "success",
             "count": len(data.get("certifications", [])),
@@ -135,7 +164,10 @@ def list_certifications(root: Path) -> dict[str, Any]:
 def has_active_certification(root: Path, domain: str, *, step_id: str = "") -> dict[str, Any]:
     """Return whether an active certification covers (domain, step_id)."""
     try:
-        data = _load(root)
+        try:
+            data = _load(root)
+        except _CertParseError:
+            return {"active": False, "error": "certifications file unparseable"}
         if domain == "lit_loop":
             domain = "literature_loop"
         for cert in data.get("certifications", []):

--- a/src/research_os/tools/actions/state/quick_mode.py
+++ b/src/research_os/tools/actions/state/quick_mode.py
@@ -104,15 +104,33 @@ def promote_to_step(
         src = (root / scratch_path).resolve()
         if not src.exists():
             return {"status": "error", "message": f"scratch path not found: {scratch_path}"}
+        # v1.5.2 stress-audit fix carried from v1.5.1 — refuse paths
+        # that escape the project root via .. or absolute paths.
+        try:
+            src.relative_to(root.resolve())
+        except ValueError:
+            return {
+                "status": "error",
+                "message": (
+                    f"scratch path must live under the project root; "
+                    f"got {src}"
+                ),
+            }
         workspace = root / "workspace"
         workspace.mkdir(parents=True, exist_ok=True)
+        # v1.5.2 stress-audit fix — parse leading-digit run with regex,
+        # not name[:2], so 100+ step projects don't collide on next_num.
         existing_nums = []
         for d in workspace.iterdir():
-            if d.is_dir() and d.name[:2].isdigit():
-                try:
-                    existing_nums.append(int(d.name[:2]))
-                except ValueError:
-                    continue
+            if not d.is_dir():
+                continue
+            m = re.match(r"^(\d+)_", d.name)
+            if not m:
+                continue
+            try:
+                existing_nums.append(int(m.group(1)))
+            except ValueError:
+                continue
         next_num = (max(existing_nums) + 1) if existing_nums else 1
         slug = _slugify(step_slug)
         step_dir = workspace / f"{next_num:02d}_{slug}"

--- a/templates/researcher_config.yaml
+++ b/templates/researcher_config.yaml
@@ -41,6 +41,21 @@ interaction:
   #   take_best_default  → AI proceeds, surfaces the chosen default for review
   ambiguity_posture: "ask_when_uncertain"
 
+# ── Audit strictness (v1.5.1) ──────────────────────────────────────────
+# How hard audits enforce gates. "light" downgrades most blockers to
+# notes; "strict" keeps every gate at full enforcement; "normal" is the
+# pre-v1.5.1 behaviour. "auto" follows tool_rigor_signals_scan — a
+# project with substantive methods.md + citations + git + preregistration
+# scores high and gets "light"; a sketch scores low and gets "strict".
+gate_strictness: "auto"               # light | normal | strict | auto
+
+# ── Project tier (v1.5.1) ──────────────────────────────────────────────
+# Sets the default audit strictness across the whole project.
+#   throwaway → light  (sandbox / exploratory; no publication intent)
+#   sketch    → normal (working draft; may or may not publish)
+#   production → strict (active path to submission / hand-off)
+project_tier: "production"            # throwaway | sketch | production
+
 # ── Match the AI model class running in your IDE ────────────────────────
 #
 # The single most important knob if you're NOT on a frontier model.


### PR DESCRIPTION
## Summary

PATCH release. Ships the three critical fixes the v1.5.1 stress audit surfaced after PR #37 had already squash-merged (same race pattern that caught v1.5.0 → v1.5.1 carry-forward).

## Fixes

1. **`templates/researcher_config.yaml`** — add `gate_strictness` + `project_tier` fields. v1.5.1 wired these in code but missed the template; fresh `research-os init` users got zero exposure.
2. **`certifications.py` data-safety bug** — transient YAML parse failure silently wiped the certifications database. Now distinguishes missing from corrupted via `_CertParseError`; refuses to save over corrupted files.
3. **`quick_mode.py promote_to_step` safety:**
   - Path-traversal guard (refuses paths escaping project root)
   - Step number regex (parses leading-digit run; v1.5.1's `name[:2]` collided on 100+ step projects)

## Validation

- preflight 14/14
- pytest 528 passed
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)