### PR TITLE
Hotfix: bust GitHub camo cache on PyPI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Research OS</h1>
 
 <p align="center">
-  <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/pypi/v/research-os.svg?color=orange&cacheSeconds=300" alt="PyPI"></a>
+  <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/pypi/v/research-os?color=orange&label=pypi" alt="PyPI"></a>
   <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg" alt="Python"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT"></a>
   <a href="https://github.com/VibhavSetlur/Research-OS/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/VibhavSetlur/Research-OS/test.yml?branch=main&label=tests" alt="tests"></a>


### PR DESCRIPTION
Tiny README-only change. Badge URL gets new shape (drop `.svg` + add `label=pypi`) so GitHub's camo image proxy refetches fresh from shields.io. shields.io already serves v2.1.1; only camo was holding stale v2.1.0.

Doc-only, no tests affected. Admin-merging.