### PR TITLE
Hotfix: PyPI badge cache-bust for v2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Research OS</h1>
 
 <p align="center">
-  <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/pypi/v/research-os?color=orange&label=pypi" alt="PyPI"></a>
+  <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/pypi/v/research-os?color=orange&label=pypi&logo=pypi&logoColor=white" alt="PyPI"></a>
   <a href="https://pypi.org/project/research-os/"><img src="https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12-blue.svg" alt="Python"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="MIT"></a>
   <a href="https://github.com/VibhavSetlur/Research-OS/actions/workflows/test.yml"><img src="https://img.shields.io/github/actions/workflow/status/VibhavSetlur/Research-OS/test.yml?branch=main&label=tests" alt="tests"></a>


### PR DESCRIPTION
Bumps the badge URL with `&logo=pypi&logoColor=white` so GitHub's camo image proxy treats it as a new URL and refetches a fresh SVG from shields.io (which already serves v2.2.0). Same pattern as PR #72.

Bonus: badge now shows the PyPI logo.