### PR TITLE
fix: resolve CodeQL mixed-import warning in test_viz_style.py

### DIFF
--- a/tests/unit/test_viz_style.py
+++ b/tests/unit/test_viz_style.py
@@ -183,7 +183,7 @@ def test_viz_package_exports_style_surface():
     palette_for / audit_figure_quality / caption_synthesise /
     step_figure_inventory so the AI's plotting script can import the
     whole figure surface from one place."""
-    import research_os.tools.actions.viz as viz
+    from research_os.tools.actions import viz
     for sym in (
         "apply_research_os_style", "RO_PALETTE", "RO_BG", "RO_FG",
         "RO_MUTED", "RO_RULE", "DESTINATION_FIGSIZES", "STYLE_RCPARAMS",


### PR DESCRIPTION
Quick follow-up to v2.4.4. CodeQL flagged `test_viz_style.py` for importing `research_os.tools.actions.viz` both via `from ... import` and `import ... as` within the same file. Swapped the `import as` to `from research_os.tools.actions import viz` so the module is consistently imported via the package-and-attribute form across the file.

No behaviour change — the test still verifies the same export surface.

## Test plan

- [x] pytest tests/unit/test_viz_style.py — 19 passed
- [x] ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)