### PR TITLE
Release v3.2.2 — hybrid mode, AI-maintained config, honest environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,76 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.2.2] — hybrid mode, AI-maintained config, honest environments (2026-06-18)
+
+Driven by an end-to-end audit of a real **research + software** project
+(`reaction-similarity`). The audit found steps advancing with an untouched
+`plan.md`, an `environment/requirements.txt` that was a full `pip freeze` of
+the *server's* conda env, a trivial workflow diagram, an empty glossary, and a
+write-once `researcher_config.yaml` that never tracked actual behaviour. This
+release closes all of those. (Numbered 3.2.2 by request; the surface is
+backwards-compatible — every existing tool keeps its name + schema.)
+
+### Added
+
+- **Hybrid mode (research + software).** New `workspace.mode: hybrid` (wizard
+  choice + `--workspace-mode hybrid`). `detect_software_components()` finds inner
+  code repos / packages (pyproject / Cargo / package.json / `.git`; RO scaffold
+  dirs excluded); `sys_boot` reports `software_components` and the workflow DAG
+  renders each as a `Software` node the latest step "informs".
+- **researcher_config is the AI's operating contract.** `sys_boot` now returns
+  `config_directives` (autonomy, gate policy, ambiguity posture, agent_notes,
+  output_types, citation_style, compute env) + a `config_reconcile_hint`. The AI
+  is instructed to FOLLOW these every session and keep them in sync via
+  `sys_config(set)` when intent shifts. New config fields: `interaction.agent_notes`
+  (free-form project directives) and `runtime.compute_environment` + `package_manager`.
+- **Live context drop-zone detection.** `inputs/context/` (+ per-step `context/`)
+  is watched: `sys_boot` peeks and `tool_route` surfaces NEW/CHANGED files since
+  the last turn, so a mid-session "I dropped a paper in context/" makes the AI read
+  it. First scan is a silent baseline.
+- **Glossary nudge.** `sys_boot.glossary_unfilled` flags an empty `docs/glossary.md`
+  once real work exists.
+- **`--mcp-scope {workspace,global}`** on `init`, plus a loud **restart notice** the
+  wizard + AGENTS surface after MCP setup.
+
+### Improved
+
+- **Step gate now inspects `plan.md`.** Scaffolding step N+1 is blocked when the
+  previous step's `plan.md` is still the unfilled seed (≥4/6 sections untouched) —
+  the exact slip seen in the audited project. Overridable via
+  `sys_path(allow_unfinalized_predecessor=true, …)`.
+- **Import-driven `environment/requirements.txt`.** `env_snapshot` + step `env_lock`
+  pin only the packages the project's own scripts import (scanned from `.py`/`.ipynb`),
+  excluding the Research-OS server stack (research_os, mcp, fastembed, …) that shares
+  the interpreter.
+- **Realistic workflow diagram.** `workspace/workflow.mermaid` + `docs/workflow_dag.mermaid`
+  are now built by one shared builder: real data-dependency edges (from
+  `data/past_step_input` symlinks, with a sequential fallback), node purpose labels,
+  status colours, dead-end styling, branch subgraphs, raw-data source node — replacing
+  the `init → every step` fan-out.
+- **`inputs/` relaxed to a soft guard.** Only `.os_state/` is hard-locked now.
+  `inputs/` is writable; `inputs/raw_data/` + `inputs/literature/` need `force=true`
+  + a confirm-with-researcher warning (and flag the intake stale); `inputs/context/`
+  is a free drop-zone.
+- **Canonical MCP entry.** One portable `mcp_server_entry()` everywhere; Claude Code's
+  real project file (root `.mcp.json`) is now written with that same entry so it stops
+  drifting to abs-path `claude mcp add` configs.
+- **Interview-before-scaffold.** AGENTS instructs the AI to ask the questions that
+  shape the scaffold (question / domain / output / autonomy / compute) and fold them
+  into the config BEFORE running init, rather than scaffolding with defaults.
+
+### Removed
+
+- **No `codemeta.json` at scaffold.** It shipped as root clutter with placeholder
+  "Anonymous Researcher" content; it's now generated on demand by `sys_export_ro_crate`
+  / the share-archive export. `CITATION.cff` is still emitted.
+- **Per-step `outputs/reports/` is no longer pre-created.** Empty in every step it became
+  a magnet for misplaced analysis artefacts; it's created on demand for presentation
+  artefacts only (the inventory tolerates its absence). `outputs/figures` + `outputs/tables`
+  unchanged.
+
+---
+
 ## [3.2.1] — plan.md is a living document (2026-06-18)
 
 PATCH. Fixes a gap in 3.2.0: the AI was told to *write* a step's `plan.md`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.2.1
+version: 3.2.2
 date-released: 2026-06-18
 keywords:
   - research-data-management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.2.1"
+version = "3.2.2"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.2.1"
+__version__ = "3.2.2"

--- a/src/research_os/cli.py
+++ b/src/research_os/cli.py
@@ -1384,6 +1384,13 @@ def build_parser() -> argparse.ArgumentParser:
                              "+ cross-study meta-analysis); "
                              "hybrid = research + software (analysis steps "
                              "plus an inner software component).")
+    p_init.add_argument("--mcp-scope", dest="mcp_scope",
+                        choices=["workspace", "global"], default="workspace",
+                        help="Where to register the MCP server. workspace "
+                             "(default) = per-project config files. global = "
+                             "also print the user-scope install command so "
+                             "research-os is available in every project. "
+                             "Either way, RESTART your IDE afterwards.")
     _ide_arg = p_init.add_argument(
         "--ide", default="all",
         help="IDE(s) to wire up: 'all' or a comma-separated list. "

--- a/src/research_os/cli.py
+++ b/src/research_os/cli.py
@@ -1373,7 +1373,7 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Add a research question (repeatable). Builds a list.")
     p_init.add_argument("--workspace-mode", dest="workspace_mode",
                         choices=["analysis", "tool_build", "exploration",
-                                 "notebook", "multi_study"],
+                                 "notebook", "multi_study", "hybrid"],
                         default=None,
                         help="What kind of work this is. "
                              "analysis (default) = linear analysis steps; "
@@ -1381,7 +1381,9 @@ def build_parser() -> argparse.ArgumentParser:
                              "exploration = scratch-first probes; "
                              "notebook = Jupyter-first notebook project; "
                              "multi_study = multi-study program (portfolio "
-                             "+ cross-study meta-analysis).")
+                             "+ cross-study meta-analysis); "
+                             "hybrid = research + software (analysis steps "
+                             "plus an inner software component).")
     _ide_arg = p_init.add_argument(
         "--ide", default="all",
         help="IDE(s) to wire up: 'all' or a comma-separated list. "

--- a/src/research_os/errors.py
+++ b/src/research_os/errors.py
@@ -24,24 +24,33 @@ class ResearchOSError(Exception):
 class WriteProtectedError(ResearchOSError):
     """Raised when a tool attempts to write to a protected directory.
 
-    Currently enforced for:
-      - inputs/        (immutable original data)
-      - .os_state/     (internal OS state, should not be manually modified)
+    Hard-locked (only ``.os_state/`` as of 3.2.2):
+      - .os_state/     internal OS state — never hand-edited.
+
+    NOTE: ``inputs/`` is **no longer** a hard-locked tree. It is the
+    researcher's source-of-truth and the AI may legitimately maintain it
+    (add context files, fix the intake, keep researcher_config.yaml in
+    sync). The two ORIGINAL input trees — ``inputs/raw_data/`` and
+    ``inputs/literature/`` — are *soft*-guarded at the sys_file_write
+    layer (deliberate ``force=true`` + a confirm-with-researcher warning),
+    NOT blocked here.
     """
 
     def __init__(self, path: "Path | str", message: str = ""):
         self.path = str(path)
         default = (
             f"Write protection violation: '{self.path}' is read-only. "
-            "The `inputs/` directory contains immutable original data "
-            "and must never be modified by tools. Write to `workspace/` instead."
+            "`.os_state/` holds internal Research-OS state and must never be "
+            "edited by hand. Write to `workspace/` instead."
         )
         super().__init__(message or default)
 
 
 # ── Guard helpers ─────────────────────────────────────────────────────────────
 
-PROTECTED_DIRECTORIES = {"inputs", ".os_state"}
+# Only .os_state is hard-locked. inputs/ relaxed to a soft guard in 3.2.2
+# (see WriteProtectedError docstring + meta_workspace._handle_sys_file_write).
+PROTECTED_DIRECTORIES = {".os_state"}
 
 
 def check_write_permitted(

--- a/src/research_os/project_ops.py
+++ b/src/research_os/project_ops.py
@@ -2676,7 +2676,56 @@ def _setup_gitignore(root: Path) -> None:
     )
 
 
-def _setup_mcp_configs(root: Path, ide_flags: list[str]) -> None:
+def mcp_server_entry() -> dict[str, Any]:
+    """The ONE canonical MCP server entry every writer uses.
+
+    Portable: `command: research-os` (resolved from PATH) + the
+    `${workspaceFolder}` env hint so the SAME global install serves every
+    project. Having a single builder is what keeps the per-IDE files from
+    drifting into the abs-path / `${workspaceFolder}` mix that shipped in
+    the reaction-similarity project.
+    """
+    return {
+        "command": "research-os",
+        "args": ["start"],
+        "env": {"RESEARCH_OS_WORKSPACE": "${workspaceFolder}"},
+    }
+
+
+def mcp_restart_notice() -> str:
+    """The notice EVERY MCP-setup path must surface: the IDE/session has to
+    reload before the freshly-wired server is visible."""
+    return (
+        "⚠ RESTART REQUIRED: the MCP server was just wired up. If your IDE / "
+        "AI session is already open, fully RESTART it (or reload the window) "
+        "so the `research-os` tools load. They will NOT appear in the current "
+        "session."
+    )
+
+
+def mcp_global_install_hint(ide_flags: list[str]) -> str:
+    """Copy-paste commands to register research-os GLOBALLY (user scope) so
+    it's available in every project — for `--mcp-scope global`."""
+    lines = [
+        "To make research-os available in EVERY project (global / user scope), "
+        "register it once with your IDE instead of per-project:",
+    ]
+    if "claude" in ide_flags or "claude_code" in ide_flags:
+        lines.append("  • Claude Code:  claude mcp add --scope user research-os -- research-os start")
+    if "cursor" in ide_flags:
+        lines.append("  • Cursor:       add the research-os entry to ~/.cursor/mcp.json")
+    if "vscode" in ide_flags:
+        lines.append("  • VS Code:      add it to your user settings.json mcp.servers")
+    lines.append(
+        "  (The per-project files were still written, so the workspace works "
+        "either way.)"
+    )
+    return "\n".join(lines)
+
+
+def _setup_mcp_configs(
+    root: Path, ide_flags: list[str], *, mcp_scope: str = "workspace",
+) -> None:
     """Drop a per-IDE MCP config + rule file so the AI auto-connects.
 
     The MCP config uses `${workspaceFolder}` so the SAME `research-os`
@@ -2686,12 +2735,12 @@ def _setup_mcp_configs(root: Path, ide_flags: list[str]) -> None:
     still work: the server reads `RESEARCH_OS_WORKSPACE` first and
     falls back to walking up from the current working directory for
     `.os_state/` (which the IDE typically launches the server in).
+
+    ``mcp_scope`` is informational here — the per-project files are always
+    written (they're harmless and make the workspace self-contained). The
+    CLI/wizard surfaces ``mcp_global_install_hint`` when scope='global'.
     """
-    mcp_entry = {
-        "command": "research-os",
-        "args": ["start"],
-        "env": {"RESEARCH_OS_WORKSPACE": "${workspaceFolder}"},
-    }
+    mcp_entry = mcp_server_entry()
     templates_dir = Path(__file__).resolve().parent.parent.parent / "templates"
 
     def _copy_rule(src_rel: str, dest: Path) -> None:
@@ -2715,6 +2764,16 @@ def _setup_mcp_configs(root: Path, ide_flags: list[str]) -> None:
         f = d / "mcp.json"
         if not f.exists():
             f.write_text(json.dumps({"mcpServers": {"research-os": mcp_entry}}, indent=2) + "\n")
+        # Claude Code reads project-scoped MCP servers from ROOT `.mcp.json`
+        # (NOT .claude/mcp.json). Writing the same canonical entry there too
+        # means Claude Code picks up RO's portable config instead of the
+        # researcher running `claude mcp add` (which bakes in absolute paths)
+        # — the abs-path-vs-portable drift seen in the wild.
+        root_mcp = root / ".mcp.json"
+        if not root_mcp.exists():
+            root_mcp.write_text(
+                json.dumps({"mcpServers": {"research-os": mcp_entry}}, indent=2) + "\n"
+            )
         _copy_rule(".claude/rules/research-os.md", d / "rules" / "research-os.md")
         _copy_rule(".claude/commands/start-session.md", d / "commands" / "start-session.md")
 

--- a/src/research_os/project_ops.py
+++ b/src/research_os/project_ops.py
@@ -417,7 +417,62 @@ SCAFFOLD_PROFILES: dict[str, dict[str, tuple[str, ...]]] = {
         "eager_dirs": _MULTI_STUDY_EAGER_DIRS,
         "lazy_dirs": _MULTI_STUDY_LAZY_DIRS,
     },
+    # hybrid (research + software) reuses the analysis layout — the
+    # software lives in its own inner repo / package, detected by
+    # detect_software_components() and surfaced in the workflow DAG +
+    # sys_boot rather than scaffolded as a fixed folder.
+    "hybrid": {
+        "top_level_dirs": TOP_LEVEL_DIRS,
+        "eager_dirs": EAGER_DIRS,
+        "lazy_dirs": LAZY_DIRS,
+    },
 }
+
+# Files whose presence in a directory marks it as a software component.
+_SOFTWARE_MARKERS = {
+    "pyproject.toml": "python", "setup.py": "python", "setup.cfg": "python",
+    "Cargo.toml": "rust", "package.json": "node", "go.mod": "go",
+    "DESCRIPTION": "r", "pom.xml": "java", "build.gradle": "java",
+}
+# Top-level dirs that are Research-OS scaffolding, never software components.
+_NON_SOFTWARE_DIRS = {
+    "workspace", "inputs", ".os_state", "environment", "docs", "synthesis",
+    "literature", "reports", "scripts", "spec", "decisions", "eval",
+}
+
+
+def detect_software_components(root: Path) -> list[dict[str, str]]:
+    """Find inner software components in a (hybrid) project.
+
+    A child directory counts as a software component when it carries a
+    build manifest (pyproject.toml / Cargo.toml / package.json / …) or its
+    own ``.git``. Research-OS scaffold dirs are excluded. This is what makes
+    a research+software project legible — e.g. KBUtilLib living beside the
+    analysis steps. Best-effort; never raises.
+    """
+    root = Path(root)
+    found: dict[str, dict[str, str]] = {}
+    try:
+        children = sorted(p for p in root.iterdir() if p.is_dir())
+    except OSError:
+        return []
+    for child in children:
+        if child.name in _NON_SOFTWARE_DIRS or child.name.startswith("."):
+            continue
+        kind: str | None = None
+        for marker, k in _SOFTWARE_MARKERS.items():
+            if (child / marker).exists():
+                kind = k
+                break
+        if kind is None and (child / ".git").exists():
+            kind = "repo"
+        if kind is not None:
+            found[child.name] = {
+                "path": child.name,
+                "name": child.name,
+                "kind": kind,
+            }
+    return list(found.values())
 
 
 def _resolve_scaffold_profile(mode: str | None) -> tuple[str, dict[str, tuple[str, ...]]]:
@@ -3619,6 +3674,7 @@ def _build_workflow_mermaid(root: Path) -> str:
         "    classDef dead_end fill:#f8d7da,stroke:#dc3545,color:#721c24,stroke-dasharray: 5 5",
         "    classDef planned fill:#e2e3e5,stroke:#6c757d,color:#333",
         "    classDef source fill:#e7f1ff,stroke:#0d6efd,color:#084298",
+        "    classDef software fill:#f0e7ff,stroke:#6f42c1,color:#3d1a78",
     ]
     if consumes_raw:
         lines.append('    raw[("inputs/raw_data")]:::source')
@@ -3650,7 +3706,27 @@ def _build_workflow_mermaid(root: Path) -> str:
     for src, dst in sorted(edges):
         lines.append(f"    {_safe(src)} --> {_safe(dst)}")
 
-    if not info:
+    # Software components (hybrid research+software projects): show the code
+    # deliverable as its own subgraph + a dashed "informs" link from the
+    # latest research step (the analysis feeds the implementation).
+    try:
+        components = detect_software_components(root)
+    except Exception:
+        components = []
+    if components:
+        lines.append('    subgraph software_component["Software"]')
+        for c in components:
+            cid = "sw_" + re.sub(r"[^A-Za-z0-9_]", "_", c["name"])
+            lines.append(f'        {cid}["{c["name"]}<br/><i>{c["kind"]}</i>"]:::software')
+        lines.append("    end")
+        all_nums = sorted(info, key=lambda p: info[p]["num"]) if info else []
+        anchor = main_sorted[-1] if main_sorted else (all_nums[-1] if all_nums else None)
+        if anchor:
+            for c in components:
+                cid = "sw_" + re.sub(r"[^A-Za-z0-9_]", "_", c["name"])
+                lines.append(f"    {_safe(anchor)} -. informs .-> {cid}")
+
+    if not info and not components:
         lines.append('    empty["No analysis steps yet"]:::planned')
 
     return "\n".join(lines)

--- a/src/research_os/project_ops.py
+++ b/src/research_os/project_ops.py
@@ -38,11 +38,16 @@ EXPERIMENT_SUBDIRS = (
     "scripts",
     "literature",        # per-step PDFs; populated by tool_literature_download(step_id=…)
     "context",           # per-step prose notes, methodology rationale, hand-overs
-    "outputs/reports",
     "outputs/figures",
     "outputs/tables",
     "environment",
 )
+# outputs/reports/ is NOT pre-created: when every step ships an empty
+# reports/ it becomes a magnet for misplaced analysis artefacts (the
+# reaction-similarity project dumped manifest.json / profile.md /
+# method_spec.md there). reports/ is for *optional* point-in-time
+# PRESENTATION artefacts (a one-off dashboard / slide); tools + the AI
+# create it on demand. The finalize inventory tolerates its absence.
 
 # 3.2 renamed the per-step data folders (data/input → data/past_step_input,
 # data/output → data/next_step_output) and added data/share. Reading code
@@ -1827,20 +1832,22 @@ def scaffold_minimal_workspace(
     _write_getting_started(root, project_name)
     _write_project_root_readme(root, project_name, state)
     _write_sharing_scripts(root, project_name)
-    # Open-science scaffolding: CITATION.cff + codemeta.json at project
-    # root so every Research OS project is citable + machine-readable
-    # from day one. Pulls author identity from researcher_config block.
+    # Open-science scaffolding: CITATION.cff at project root so every
+    # Research OS project is citable from day one. Pulls author identity
+    # from the researcher_config block. codemeta.json + ro-crate-metadata
+    # are NO LONGER emitted at scaffold — they shipped as root clutter with
+    # placeholder "Anonymous Researcher" content nobody asked for. They are
+    # generated on demand by `sys_export_ro_crate` / the share-archive
+    # export, which is when a machine-readable manifest is actually needed.
     try:
         from research_os.tools.actions.state.citation import (
             emit_project_citation_cff,
         )
-        from research_os.tools.actions.state.ro_crate import build_codemeta
 
         researcher_block = ((config_overrides or {}).get("researcher")
                             or {})
         emit_project_citation_cff(root, project_name=project_name,
                                   researcher=researcher_block)
-        build_codemeta(root)
     except Exception:
         # Open-science manifests are best-effort; never block scaffold.
         pass
@@ -2987,13 +2994,14 @@ def _seed_step_subfolder_readmes(
         "interactive `.html` figures suit networks / large multi-panels.\n"
         "- **`tables/`** — CSV / TSV tables (analysis outputs). Each table "
         "SHOULD have a sibling `<name>.caption.md`.\n"
-        "- **`reports/`** — *optional* snapshot presentation artefacts you "
-        "build at a point in time to PRESENT — a one-off dashboard for a "
-        "committee, a slide for a journal club, a diagram for a "
-        "collaboration review. These are NOT analysis-script outputs and NOT "
-        "where findings live (findings → `conclusions.md`). Keeping them "
-        "here avoids cluttering `synthesis/`. Header each with its date + "
-        "intended audience.\n\n"
+        "- **`reports/`** — *optional, created on demand* (not pre-made). For "
+        "point-in-time PRESENTATION artefacts you build to SHOW someone — a "
+        "one-off dashboard for a committee, a slide for a journal club. These "
+        "are NOT analysis-script outputs (those are `figures/` + `tables/`), "
+        "NOT intermediate data (that's `data/next_step_output/`), and NOT "
+        "where findings live (findings → `conclusions.md`). Only `mkdir` this "
+        "when you genuinely build a presentation artefact; header each with "
+        "its date + intended audience.\n\n"
         "Follow `figure_guidelines` (DPI ≥150 screen / ≥300 print, colour-blind "
         "safe palette, axis units). The AI MUST `sys_file_read` each figure "
         "before declaring the step done (catches legend-over-plot, missing "

--- a/src/research_os/project_ops.py
+++ b/src/research_os/project_ops.py
@@ -3493,6 +3493,161 @@ def _update_analysis_mermaid_block(root: Path, mermaid_content: str) -> None:
     analysis_path.write_text(content[:start] + new_block + content[end:])
 
 
+def _step_purpose(exp_dir: Path, fallback: str) -> str:
+    """A short (<=46 char) one-liner for a workflow node, taken from the
+    step's README ``## Goal`` (skipping the unfilled stub). Falls back to
+    the step name."""
+    readme = exp_dir / "README.md"
+    if readme.exists():
+        try:
+            txt = readme.read_text()
+        except OSError:
+            txt = ""
+        m = re.search(r"^##\s+Goal\s*\n+(.+)", txt, re.M)
+        if m:
+            line = re.sub(r"\s+", " ", m.group(1).strip().lstrip("-* ").strip())
+            if line and not line.startswith(("*(", "_(")):
+                return line[:46]
+    return re.sub(r"\s+", " ", fallback)[:46]
+
+
+def _build_workflow_mermaid(root: Path) -> str:
+    """Build a realistic workflow DAG (graph TD) for the project.
+
+    Unlike the old `init --> every step` fan-out, this derives REAL
+    data-dependency edges from each step's ``data/past_step_input``
+    symlinks (→ another step's ``data/next_step_output`` or
+    ``inputs/raw_data``), labels nodes with status + a one-line purpose,
+    styles dead-ends, groups branch paths (``*_PATH_k``) into subgraphs,
+    and falls back to a sequential chain for main-path steps whose inputs
+    aren't symlinked yet. Shared by ``workspace/workflow.mermaid`` and
+    ``docs/workflow_dag.mermaid`` so the two never drift.
+    """
+    from research_os.tools.actions.state.path import list_paths
+
+    workspace = root / "workspace"
+    try:
+        steps = list_paths(root).get("paths", []) or []
+    except Exception:
+        steps = []
+
+    def _num(pid: str) -> int:
+        m = re.match(r"^(\d+)", pid)
+        return int(m.group(1)) if m else 0
+
+    def _safe(pid: str) -> str:
+        return re.sub(r"[^A-Za-z0-9_]", "_", pid)
+
+    info: dict[str, dict[str, Any]] = {}
+    for s in steps:
+        pid = s["path_id"]
+        exp = root / s.get("experiment_dir", f"workspace/{pid}")
+        info[pid] = {
+            "status": s.get("status", "active"),
+            "lineage": _extract_path_lineage(pid),
+            "purpose": _step_purpose(exp, s.get("name") or pid),
+            "exp": exp,
+            "num": _num(pid),
+            "short": pid.replace("__DEAD_END", ""),
+        }
+
+    # ── edges from data symlinks ──────────────────────────────────────
+    try:
+        ws_resolved = workspace.resolve()
+        raw_resolved = (root / "inputs" / "raw_data").resolve()
+    except OSError:
+        ws_resolved, raw_resolved = workspace, root / "inputs" / "raw_data"
+    edges: set[tuple[str, str]] = set()
+    consumes_raw: set[str] = set()
+    for pid, meta in info.items():
+        din = step_input_link(meta["exp"])
+        targets: list[Path] = []
+        if din.is_symlink():
+            try:
+                targets.append(din.resolve())
+            except OSError:
+                pass
+        elif din.is_dir():
+            for ch in din.iterdir():
+                if ch.is_symlink():
+                    try:
+                        targets.append(ch.resolve())
+                    except OSError:
+                        pass
+        for t in targets:
+            try:
+                rel = t.relative_to(ws_resolved)
+            except (ValueError, OSError):
+                try:
+                    t.relative_to(raw_resolved)
+                    consumes_raw.add(pid)
+                except (ValueError, OSError):
+                    pass
+                continue
+            anc = next((p for p in rel.parts if re.match(r"^\d{2,3}_", p)), None)
+            if anc and anc in info and anc != pid:
+                edges.add((anc, pid))
+
+    # ── fallback sequential chain for un-wired main-path steps ────────
+    main_sorted = sorted(
+        (p for p in info if info[p]["lineage"] is None), key=lambda p: info[p]["num"]
+    )
+    have_in = {dst for _, dst in edges}
+    prev: str | None = None
+    for pid in main_sorted:
+        if prev and pid not in have_in and (prev, pid) not in edges:
+            edges.add((prev, pid))
+            have_in.add(pid)
+        prev = pid
+    if main_sorted and main_sorted[0] not in have_in:
+        consumes_raw.add(main_sorted[0])
+
+    # ── assemble ──────────────────────────────────────────────────────
+    css_for = {"completed": "completed", "active": "active", "dead_end": "dead_end"}
+    lines = [
+        "graph TD",
+        "    classDef active fill:#fff3cd,stroke:#856404,color:#333",
+        "    classDef completed fill:#d4edda,stroke:#28a745,color:#155724",
+        "    classDef dead_end fill:#f8d7da,stroke:#dc3545,color:#721c24,stroke-dasharray: 5 5",
+        "    classDef planned fill:#e2e3e5,stroke:#6c757d,color:#333",
+        "    classDef source fill:#e7f1ff,stroke:#0d6efd,color:#084298",
+    ]
+    if consumes_raw:
+        lines.append('    raw[("inputs/raw_data")]:::source')
+
+    def _node_line(pid: str, indent: str = "    ") -> str:
+        meta = info[pid]
+        css = css_for.get(meta["status"], "planned")
+        label = meta["short"]
+        purpose = meta["purpose"]
+        if purpose and purpose.lower() not in (label.lower(), ""):
+            label = f"{label}<br/><i>{purpose}</i>"
+        return f'{indent}{_safe(pid)}["{label}"]:::{css}'
+
+    # group branch lineages into subgraphs; main path stays ungrouped.
+    lineages = sorted({m["lineage"] for m in info.values() if m["lineage"] is not None})
+    for pid in main_sorted:
+        lines.append(_node_line(pid))
+    for k in lineages:
+        members = sorted(
+            (p for p in info if info[p]["lineage"] == k), key=lambda p: info[p]["num"]
+        )
+        lines.append(f'    subgraph path_{k}["Path {k} — alternative approach"]')
+        for pid in members:
+            lines.append(_node_line(pid, indent="        "))
+        lines.append("    end")
+
+    for pid in consumes_raw:
+        lines.append(f"    raw --> {_safe(pid)}")
+    for src, dst in sorted(edges):
+        lines.append(f"    {_safe(src)} --> {_safe(dst)}")
+
+    if not info:
+        lines.append('    empty["No analysis steps yet"]:::planned')
+
+    return "\n".join(lines)
+
+
 def _update_workflow_mermaid(root: Path) -> None:
     """Regenerate workspace/workflow.mermaid + analysis.md block + (optional) PNG.
 
@@ -3510,29 +3665,10 @@ def _update_workflow_mermaid(root: Path) -> None:
         # is exactly what we want.
         return
     try:
-        from research_os.tools.actions.state.path import list_paths
-
-        paths = list_paths(root).get("paths", []) or []
+        text = _build_workflow_mermaid(root)
     except Exception:
-        paths = []
-
-    lines = ["graph TD", "    init[Initialise Project]:::complete"]
-    for p in paths:
-        pid = re.sub(r"[^a-zA-Z0-9_]", "_", p["path_id"])
-        label = p.get("name") or p["path_id"]
-        status = p.get("status", "active")
-        css = {"completed": "complete", "active": "running", "dead_end": "failed"}.get(status, "planned")
-        lines.append(f"    {pid}[{label}]:::{css}")
-        lines.append(f"    init --> {pid}")
-    lines.extend(
-        [
-            "    classDef complete fill:#d4edda,stroke:#28a745",
-            "    classDef running  fill:#fff3cd,stroke:#ffc107",
-            "    classDef failed   fill:#f8d7da,stroke:#dc3545,stroke-dasharray: 5 5",
-            "    classDef planned  fill:#e2e3e5,stroke:#6c757d",
-        ]
-    )
-    text = "\n".join(lines)
+        # Never let a diagram refresh break step create/finalize.
+        return
     mermaid_path = root / "workspace" / "workflow.mermaid"
     mermaid_path.write_text(text + "\n")
     _update_analysis_mermaid_block(root, text)

--- a/src/research_os/project_ops.py
+++ b/src/research_os/project_ops.py
@@ -3107,9 +3107,12 @@ def create_numbered_experiment(
         prev = existing_main_steps[-1]
         prev_readme = prev / "README.md"
         prev_conc = prev / "conclusions.md"
+        prev_plan = prev / "plan.md"
         if prev_readme.exists() and prev_conc.exists():
             r_txt = prev_readme.read_text()
             c_txt = prev_conc.read_text()
+            # plan.md is optional on pre-3.2 steps; only gate when present.
+            p_txt = prev_plan.read_text() if prev_plan.exists() else ""
             placeholder_markers_readme = (
                 "*(2-3 sentences a colleague",
                 "*(list inputs used)*",
@@ -3122,21 +3125,51 @@ def create_numbered_experiment(
                 "*(Dataset shape",
                 "*(What this step cannot conclude",
             )
+            # plan.md seed sections (see the plan.md writer below). A plan
+            # that was genuinely written before the work fills the design
+            # core; a plan that was SKIPPED leaves these raw. Field-proof:
+            # every step of the reaction-similarity project shipped all six
+            # of these untouched yet still advanced — because the
+            # predecessor gate never inspected plan.md. It does now.
+            placeholder_markers_plan = (
+                "*(Recap the previous step's outcome",       # Where we are
+                "*(The goal for",                            # What this step will do
+                "*(How it advances",                         # Why this step, why now
+                "*(The decisions you want",                  # Open questions
+                "*(Update this AS YOU WORK",                 # Progress & deviations
+                "*(Where this likely leads",                 # Anticipated next steps
+            )
             unfilled_readme = sum(m in r_txt for m in placeholder_markers_readme)
             unfilled_conc = sum(m in c_txt for m in placeholder_markers_conc)
-            if unfilled_readme >= 3 or unfilled_conc >= 2:
+            unfilled_plan = sum(m in p_txt for m in placeholder_markers_plan)
+            plan_skipped = bool(p_txt) and unfilled_plan >= 4
+            if unfilled_readme >= 3 or unfilled_conc >= 2 or plan_skipped:
+                bits = []
+                if unfilled_readme >= 3:
+                    bits.append(f"README has {unfilled_readme} unfilled stubs")
+                if unfilled_conc >= 2:
+                    bits.append(f"conclusions.md has {unfilled_conc}")
+                if plan_skipped:
+                    bits.append(
+                        f"plan.md is still the unfilled seed "
+                        f"({unfilled_plan}/6 sections untouched)"
+                    )
                 raise ValueError(
                     f"Cannot scaffold the next step: previous step "
                     f"`{prev.name}` is still in placeholder form "
-                    f"(README has {unfilled_readme} unfilled stubs, "
-                    f"conclusions.md has {unfilled_conc}). Call "
-                    f"`tool_path_finalize` on `{prev.name}` first to "
-                    "lock its findings into workspace/analysis.md + "
-                    "methods.md + tools.md + citations.md. If this is a "
-                    "data-plumbing step that legitimately has nothing "
-                    "to conclude, the AI should explicitly write 'No "
-                    "substantive findings — see step purpose in README' "
-                    "into the conclusions stubs before re-trying."
+                    f"({'; '.join(bits)}). Fill the step's README "
+                    "(`## In plain English`, `## Decision`), conclusions.md "
+                    "(`## Findings`, `## Decision`), and plan.md (the design + "
+                    "`## Progress & deviations from plan` reconcile), then call "
+                    f"`tool_path_finalize` on `{prev.name}` to lock its "
+                    "findings into workspace/analysis.md + methods.md + "
+                    "tools.md + citations.md. If this is a data-plumbing step "
+                    "that legitimately has nothing to conclude, write 'No "
+                    "substantive findings — see step purpose in README' into "
+                    "the stubs before re-trying. To override deliberately, "
+                    "call `sys_path(operation='create', "
+                    "allow_unfinalized_predecessor=true, override_rationale=…)` "
+                    "(logged to workspace/logs/override_log.md)."
                 )
 
     # Numbering is CONTINUOUS across the whole workspace — flat steps AND

--- a/src/research_os/server/handlers/meta_help.py
+++ b/src/research_os/server/handlers/meta_help.py
@@ -65,7 +65,7 @@ def _handle_sys_help(name, arguments, root):
             "Don't one-shot 400-line scripts — tool_step_pipeline_define + atomic sub-tasks.",
             "Don't invent citations — synthesis tools VERIFY every citation against Crossref/S2/PubMed/arXiv.",
             "Don't pick a method or library from training memory — tool_research_method / tool_research_tool first.",
-            "Don't write under inputs/raw_data or inputs/literature (immutable; server blocks it).",
+            "Treat inputs/raw_data + inputs/literature as source-of-truth: editing needs force=true + researcher OK (soft guard). inputs/context is a free drop-zone — write there freely.",
             "Don't skip the ask_user from tool_route — asking once costs less than picking wrong.",
             "Don't re-route after the researcher already picked one — use tool_plan(operation='clear') if they pivoted.",
             "Don't bypass a quality gate without override_rationale — the pre-submission audit will surface every silent bypass.",
@@ -142,7 +142,7 @@ def _handle_sys_help(name, arguments, root):
                 "override_rationale is mandatory — silent bypass is a hard rule violation.",
                 "Each bypass appends to workspace/logs/override_log.md.",
                 "audit/pre_submission_checklist surfaces every unresolved bypass; RED if unresolved + no rationale.",
-                "Hard rules (no fabricated citations, no inputs/raw_data writes) are absolute — the quality gate is the ONLY authorised escape hatch.",
+                "Hard rules (no fabricated citations; .os_state is never hand-edited) are absolute. Editing original inputs (raw_data/literature) is a soft guard: force=true + researcher OK + log staleness.",
             ],
         }))
     if topic == "recovery":

--- a/src/research_os/server/handlers/meta_routing.py
+++ b/src/research_os/server/handlers/meta_routing.py
@@ -217,6 +217,23 @@ def _handle_tool_route(name, arguments, root):
         # Phase-9 cross-cutting: name the next tool to call so the AI
         # doesn't burn a turn deciding.
         res.setdefault("recommended_action", _recommended_action_for_route(res))
+        # Live drop-zone: surface (and consume) any context the researcher
+        # dropped since the last prompt. Fires on the turn after the drop —
+        # "I put a paper in context/" → the AI is told to read it.
+        try:
+            from research_os.tools.actions.state.context_watch import (
+                detect_new_context,
+            )
+
+            nc = detect_new_context(root, update_marker=True)
+            if nc.get("new_files") or nc.get("changed_files"):
+                res["new_context"] = {
+                    "new_files": nc.get("new_files", []),
+                    "changed_files": nc.get("changed_files", []),
+                    "hint": nc.get("hint", ""),
+                }
+        except Exception:
+            pass
         return _text(_success(res))
     return _text(_error(res.get("message", "tool_route failed")))
 

--- a/src/research_os/server/handlers/meta_workspace.py
+++ b/src/research_os/server/handlers/meta_workspace.py
@@ -153,15 +153,38 @@ def _handle_sys_file_write(name, arguments, root):
     root_resolved = Path(root).resolve()
     rel = str(p.relative_to(root_resolved))
 
-    # Central write-permission gate (inputs/, .os_state/) — was previously
-    # bypassed for sys_file_write; only project_ops used check_write_permitted.
+    # Central write-permission gate. As of 3.2.2 only `.os_state/` is
+    # hard-locked (internal state, never hand-edited).
     try:
         check_write_permitted(p, root=root_resolved)
     except WriteProtectedError as exc:
-        # Literature-index updates inside inputs/literature/ are the one
-        # documented mutation allowed under the immutable input tree.
-        if not rel.endswith("literature_index.yaml"):
-            return _text(_error(str(exc)))
+        return _text(_error(str(exc)))
+
+    # inputs/ is the researcher's source-of-truth — writable. But the two
+    # ORIGINAL trees (raw_data, literature) get a SOFT guard: a deliberate
+    # force=true + a confirm-with-researcher warning, so the AI never
+    # silently rewrites primary data / provenance. literature_index.yaml
+    # (the AI-maintained citation ledger) is the documented exception.
+    soft_warning = None
+    is_original_input = (
+        rel.startswith(("inputs/raw_data/", "inputs/literature/"))
+        and not rel.endswith("literature_index.yaml")
+    )
+    if is_original_input and not force:
+        return _text(_error(
+            f"`{rel}` is original input data — your project's source-of-truth. "
+            "Editing it changes provenance and staleness the intake SHA-256 "
+            "inventory. Confirm with the researcher, then pass force=true. "
+            "(To ADD new inputs, prefer the wizard / tool_context_intake; for "
+            "free-form context notes, write under inputs/context/ — no force "
+            "needed.)"
+        ))
+    if is_original_input and force:
+        soft_warning = (
+            f"Modified original input `{rel}` — provenance changed. Confirm "
+            "the researcher approved this; the intake inventory is now stale "
+            "(re-run mem_intake_regenerate)."
+        )
     if rel.startswith("synthesis/") and p.exists() and not force:
         return _text(_error("synthesis/ files exist: pass force=true to overwrite."))
 
@@ -169,7 +192,10 @@ def _handle_sys_file_write(name, arguments, root):
     p.write_text(arguments["content"])
     if rel.startswith("workspace/"):
         _update_manifest(root)
-    return _text(_success({"written": True, "checksum": compute_file_hash(p)}))
+    payload = {"written": True, "checksum": compute_file_hash(p)}
+    if soft_warning:
+        payload["warning"] = soft_warning
+    return _text(_success(payload))
 
 
 def _handle_sys_file_list(name, arguments, root):

--- a/src/research_os/tools/actions/exec/environment.py
+++ b/src/research_os/tools/actions/exec/environment.py
@@ -121,6 +121,127 @@ def _detect_languages_in_use(root: Path) -> set[str]:
     return detected
 
 
+# Top-level import names we never pin as a project dependency.
+_STDLIB_MODULES = set(getattr(sys, "stdlib_module_names", set())) | {
+    "__future__", "__main__",
+}
+# The Research-OS server stack runs in the SAME interpreter as the MCP
+# server, so a naive `pip freeze` dumps research_os + mcp + fastembed +
+# firecrawl + semanticscholar + … into every project's requirements.txt
+# (exactly what shipped in the reaction-similarity project). A research
+# project's requirements describe the PROJECT's analysis deps, never the
+# server orchestrating it — so research_os is always excluded.
+_RESEARCH_OS_IMPORT_NAMES = {"research_os"}
+_RESEARCH_OS_DIST_NAMES = {"research-os", "research_os"}
+
+
+def _norm_dist(name: str) -> str:
+    """PEP 503 normalised distribution name (lowercase, runs of -_. → -)."""
+    import re
+    return re.sub(r"[-_.]+", "-", (name or "").strip().lower())
+
+
+def _scan_python_imports(root: Path) -> set[str]:
+    """Top-level module names imported by the project's OWN Python sources.
+
+    Regex-based (never executes code), so it survives half-written
+    scripts. Scans ``workspace/**/*.py``, root ``scripts/**/*.py``, and the
+    code cells of any ``*.ipynb`` under those trees.
+    """
+    import json as _json
+    import re
+
+    pat = re.compile(
+        r"^[ \t]*(?:import[ \t]+([a-zA-Z0-9_.]+)"
+        r"|from[ \t]+([a-zA-Z0-9_.]+)[ \t]+import)",
+        re.M,
+    )
+    mods: set[str] = set()
+
+    def _harvest(text: str) -> None:
+        for m in pat.finditer(text):
+            raw = m.group(1) or m.group(2) or ""
+            top = raw.split(".", 1)[0].strip()
+            if top:
+                mods.add(top)
+
+    for base in (root / "workspace", root / "scripts"):
+        if not base.exists():
+            continue
+        for p in base.rglob("*.py"):
+            try:
+                _harvest(p.read_text(errors="ignore"))
+            except OSError:
+                pass
+        for p in base.rglob("*.ipynb"):
+            try:
+                nb = _json.loads(p.read_text(errors="ignore"))
+            except (OSError, ValueError):
+                continue
+            for cell in nb.get("cells", []):
+                if cell.get("cell_type") != "code":
+                    continue
+                src = cell.get("source", "")
+                _harvest("".join(src) if isinstance(src, list) else str(src))
+    return mods
+
+
+def _project_python_requirements(root: Path) -> str:
+    """requirements.txt built from the project's OWN imports.
+
+    Each distribution the project's scripts import is pinned to the
+    version installed when the snapshot ran. The Research-OS server stack
+    is excluded (it ships with the MCP server, not the project). Local
+    modules and as-yet-uninstalled imports are skipped — you can't pin
+    what isn't on disk.
+    """
+    from importlib import metadata as im
+
+    installed: dict[str, str] = {}
+    try:
+        for dist in im.distributions():
+            nm = (dist.metadata["Name"] or "").strip()
+            if nm:
+                installed[_norm_dist(nm)] = dist.version
+    except Exception:  # pragma: no cover - importlib edge cases
+        pass
+
+    try:
+        mod_to_dists = im.packages_distributions()
+    except Exception:  # pragma: no cover
+        mod_to_dists = {}
+
+    project_dists: set[str] = set()
+    for mod in _scan_python_imports(root):
+        if mod in _STDLIB_MODULES or mod in _RESEARCH_OS_IMPORT_NAMES:
+            continue
+        for d in mod_to_dists.get(mod, []):
+            if _norm_dist(d) not in _RESEARCH_OS_DIST_NAMES:
+                project_dists.add(d)
+
+    lines = []
+    for d in sorted(project_dists, key=str.lower):
+        ver = installed.get(_norm_dist(d))
+        lines.append(f"{d}=={ver}" if ver else d)
+
+    header = [
+        "# Project Python dependencies.",
+        "#",
+        "# The packages THIS project's scripts import, pinned to the",
+        "# versions installed when sys_env_snapshot last ran. Regenerate",
+        "# after adding imports. The Research-OS server stack (research_os,",
+        "# mcp, fastembed, …) is intentionally excluded — it ships with the",
+        "# MCP server, not with your analysis.",
+    ]
+    if not lines:
+        header += [
+            "#",
+            "# No third-party imports detected yet — this fills in as your",
+            "# analysis scripts start importing packages.",
+        ]
+    return "\n".join(header + [""] + lines).rstrip() + "\n"
+
+
 def _domain_package_recommendations(
     domain_hints: list[str], in_use: set[str],
 ) -> dict[str, list[str]]:
@@ -339,20 +460,21 @@ def env_snapshot(
         session["detected_languages"] = sorted(in_use)
 
         # ── Python ────────────────────────────────────────────────
+        # Import-driven, NOT `pip freeze`: the MCP server runs in this
+        # interpreter, so a raw freeze leaks research_os + its server
+        # stack into the project's requirements.txt. Pin only what the
+        # project's own scripts import.
         if "python" in in_use:
             try:
-                res = subprocess.run(
-                    [sys.executable, "-m", "pip", "freeze"],
-                    capture_output=True, text=True, timeout=60,
+                (env_dir / "requirements.txt").write_text(
+                    _project_python_requirements(root)
                 )
-                if res.returncode == 0:
-                    (env_dir / "requirements.txt").write_text(res.stdout)
-                    session["languages"].append({
-                        "name": "python",
-                        "version": sys.version.split()[0],
-                        "manager": "pip",
-                        "file": "requirements.txt",
-                    })
+                session["languages"].append({
+                    "name": "python",
+                    "version": sys.version.split()[0],
+                    "manager": "pip",
+                    "file": "requirements.txt",
+                })
             except Exception as e:
                 logger.warning(f"Python snapshot failed: {e}")
 
@@ -570,21 +692,13 @@ def step_env_lock(
         (env_dir / "python_version.txt").write_text(py_version + "\n")
         artifacts.append("python_version.txt")
 
-        # pip freeze
-        res = subprocess.run(
-            [sys.executable, "-m", "pip", "freeze"],
-            capture_output=True,
-            text=True,
-            timeout=60,
+        # Import-driven requirements (same rationale as env_snapshot: the
+        # MCP server shares this interpreter, so a raw `pip freeze` would
+        # archive research_os + its server stack into the step lock).
+        (env_dir / "requirements.txt").write_text(
+            _project_python_requirements(root)
         )
-        if res.returncode == 0:
-            (env_dir / "requirements.txt").write_text(res.stdout)
-            artifacts.append("requirements.txt")
-        else:
-            return {
-                "status": "error",
-                "message": f"pip freeze failed: {res.stderr.strip()}",
-            }
+        artifacts.append("requirements.txt")
 
         session: dict[str, Any] = {
             "step_id": step_dir.name,

--- a/src/research_os/tools/actions/router.py
+++ b/src/research_os/tools/actions/router.py
@@ -828,11 +828,50 @@ def sys_boot(root: Path, *, lean: bool = False) -> dict[str, Any]:
                 "compute_environment": (cfg.get("runtime") or {}).get("compute_environment", ""),
             },
             "config_reconcile_hint": _config_reconcile_hint(cfg),
+            # Live drop-zone awareness + glossary nudge (peek only — the
+            # marker is consumed by tool_route so each drop surfaces once).
+            "new_context": _boot_new_context(root),
+            "glossary_unfilled": _boot_glossary_unfilled(root, n_finalized),
             "advice": _boot_advice(pause, active_plan, state, cfg),
         }
     except Exception as e:
         logger.exception("sys_boot failed")
         return {"status": "error", "message": str(e)}
+
+
+def _boot_new_context(root: Path) -> dict:
+    """sys_boot peek at the context drop-zone (does NOT consume the marker
+    — tool_route consumes it so each drop surfaces once on the next prompt)."""
+    try:
+        from research_os.tools.actions.state.context_watch import detect_new_context
+
+        nc = detect_new_context(root, update_marker=False)
+        return {
+            "new_files": nc.get("new_files", []),
+            "changed_files": nc.get("changed_files", []),
+            "hint": nc.get("hint", ""),
+        }
+    except Exception:
+        return {"new_files": [], "changed_files": [], "hint": ""}
+
+
+def _boot_glossary_unfilled(root: Path, n_finalized: int) -> dict:
+    """Nudge to populate docs/glossary.md once the project has substance
+    (≥1 finalized step) but the glossary is still header-only."""
+    try:
+        from research_os.tools.actions.state.context_watch import glossary_unfilled
+
+        empty = glossary_unfilled(root)
+    except Exception:
+        empty = False
+    hint = ""
+    if empty and n_finalized >= 1:
+        hint = (
+            "docs/glossary.md is empty — add the domain terms you've used "
+            "(term | definition | source) so a non-expert reader (and the "
+            "synthesis) can follow the work."
+        )
+    return {"empty": bool(empty), "nudge": bool(hint), "hint": hint}
 
 
 def _config_reconcile_hint(cfg: dict) -> str:

--- a/src/research_os/tools/actions/router.py
+++ b/src/research_os/tools/actions/router.py
@@ -814,11 +814,58 @@ def sys_boot(root: Path, *, lean: bool = False) -> dict[str, Any]:
             "handoff_hint": handoff_hint,
             "n_finalized_steps": n_finalized,
             "freshness": freshness,
+            # The behavioural contract from researcher_config, surfaced
+            # compactly so the AI FOLLOWS it every session AND keeps it in
+            # sync (a secondary AGENTS.md). See config_reconcile_hint.
+            "config_directives": {
+                "autonomy": (cfg.get("interaction") or {}).get("autonomy_level", "supervised"),
+                "quality_gate_policy": (cfg.get("interaction") or {}).get("quality_gate_policy", "enforce"),
+                "ambiguity_posture": (cfg.get("interaction") or {}).get("ambiguity_posture", "ask_when_uncertain"),
+                "agent_notes": (cfg.get("interaction") or {}).get("agent_notes", ""),
+                "output_types": (cfg.get("research_goal") or {}).get("output_types", []),
+                "target_venue": (cfg.get("research_goal") or {}).get("target_venue", ""),
+                "citation_style": (cfg.get("writing_preferences") or {}).get("citation_style", ""),
+                "compute_environment": (cfg.get("runtime") or {}).get("compute_environment", ""),
+            },
+            "config_reconcile_hint": _config_reconcile_hint(cfg),
             "advice": _boot_advice(pause, active_plan, state, cfg),
         }
     except Exception as e:
         logger.exception("sys_boot failed")
         return {"status": "error", "message": str(e)}
+
+
+def _config_reconcile_hint(cfg: dict) -> str:
+    """One-line nudge: researcher_config is the AI's operating contract;
+    keep the behaviour-shaping fields in sync with what the researcher
+    asks, and fill the blanks that matter for downstream gates."""
+    inter = cfg.get("interaction") or {}
+    goal = cfg.get("research_goal") or {}
+    runtime = cfg.get("runtime") or {}
+    gaps: list[str] = []
+    if not (goal.get("output_types") or []):
+        gaps.append(
+            "research_goal.output_types is blank (exploratory — no auto "
+            "paper/dashboard); set it the moment the researcher names a "
+            "deliverable"
+        )
+    if not (runtime.get("compute_environment") or "").strip():
+        gaps.append(
+            "runtime.compute_environment is blank — record the env "
+            "(conda/module/docker) so reproduction is right"
+        )
+    base = (
+        "researcher_config is your operating contract: FOLLOW "
+        f"autonomy='{inter.get('autonomy_level', 'supervised')}', "
+        f"quality_gate_policy='{inter.get('quality_gate_policy', 'enforce')}', "
+        f"ambiguity_posture='{inter.get('ambiguity_posture', 'ask_when_uncertain')}'. "
+        "When the researcher changes intent (\"be autonomous\", \"we're "
+        "writing a paper\", \"use Vancouver\"), UPDATE it via "
+        "sys_config(operation='set')."
+    )
+    if gaps:
+        base += " Gaps to fill from the conversation: " + "; ".join(gaps) + "."
+    return base
 
 
 def _classify_pause(entries: list[dict], root: Path) -> str:

--- a/src/research_os/tools/actions/router.py
+++ b/src/research_os/tools/actions/router.py
@@ -832,6 +832,10 @@ def sys_boot(root: Path, *, lean: bool = False) -> dict[str, Any]:
             # marker is consumed by tool_route so each drop surfaces once).
             "new_context": _boot_new_context(root),
             "glossary_unfilled": _boot_glossary_unfilled(root, n_finalized),
+            # Hybrid (research + software): inner code components, so the AI
+            # governs the research in workspace/ AND the code via tool_git /
+            # tool_build on the inner repo.
+            "software_components": _boot_software_components(root),
             "advice": _boot_advice(pause, active_plan, state, cfg),
         }
     except Exception as e:
@@ -853,6 +857,16 @@ def _boot_new_context(root: Path) -> dict:
         }
     except Exception:
         return {"new_files": [], "changed_files": [], "hint": ""}
+
+
+def _boot_software_components(root: Path) -> list:
+    """Inner software components (hybrid projects) — empty for pure analysis."""
+    try:
+        from research_os.project_ops import detect_software_components
+
+        return detect_software_components(root)
+    except Exception:
+        return []
 
 
 def _boot_glossary_unfilled(root: Path, n_finalized: int) -> dict:

--- a/src/research_os/tools/actions/state/config.py
+++ b/src/research_os/tools/actions/state/config.py
@@ -430,6 +430,11 @@ def get_interaction_policy(root: Path) -> dict[str, str]:
 
 VALID_WORKSPACE_MODES = (
     "analysis", "tool_build", "exploration", "notebook", "multi_study",
+    # hybrid = a research project that ALSO ships software. Routes + scaffolds
+    # like analysis (numbered research steps) AND surfaces the inner software
+    # component(s) — the reaction-similarity shape: characterise a method in
+    # workspace/ steps, then implement it as a library in an inner repo.
+    "hybrid",
 )
 
 

--- a/src/research_os/tools/actions/state/config.py
+++ b/src/research_os/tools/actions/state/config.py
@@ -130,13 +130,23 @@ workspace:
     test: ""              # e.g. "pytest -q" | "cargo test" | "npm test"
     lint: ""              # e.g. "ruff check ." | "cargo clippy" | "eslint ."
 
-# ── What you want to produce (blank = AI suggests; start exploratory) ───
+# ── What you want to produce ────────────────────────────────────────────
+# Blank output_types = EXPLORATORY: the AI will NOT auto-build a paper /
+# dashboard / poster you didn't ask for (synthesis gates on this). You
+# don't have to decide up front. The AI fills this in from your goal —
+# say "we're submitting to Nature" and it sets output_types + target_venue
+# + writing_preferences.* and keeps them in sync as the goal shifts.
 research_goal:
   output_types: []               # paper | abstract | poster | dashboard | report | exploratory
   target_venue: ""               # journal | conference | preprint | dissertation | report
   poster_dimensions: "36x48"
 
-# ── How the AI should behave ────────────────────────────────────────────
+# ── How the AI should behave — the AI's operating contract ──────────────
+# Treat this block as a secondary AGENTS.md. The AI READS it every session
+# (via sys_boot) and FOLLOWS it, and it KEEPS IT IN SYNC with what you ask:
+# say "just be autonomous" → it sets autonomy_level: autopilot; "ask before
+# big moves" → supervised; "teach me as we go" → coaching. It never
+# silently overrides a value you set by hand.
 interaction:
   autonomy_level: "supervised"   # manual | supervised | autopilot | coaching
   # coaching → AI doesn't auto-execute; surfaces pedagogical preludes,
@@ -158,6 +168,13 @@ interaction:
   #   ask_when_uncertain → default; AI asks a one-line follow-up
   #   take_best_default  → AI proceeds, surfaces the chosen default for review
   ambiguity_posture: "ask_when_uncertain"
+
+  # Free-form, project-specific directives the AI records + obeys — the
+  # "how to act on THIS project" notes that don't fit a knob above (e.g.
+  # "always segregate transport reactions", "prefer DRFP over structural
+  # fingerprints", "never touch the prod DB"). The AI appends here as it
+  # learns your preferences; edit by hand any time.
+  agent_notes: ""
 
 # ── Audit strictness ───────────────────────────────────────────────────
 # How hard audits enforce gates. "light" downgrades most blockers to
@@ -252,9 +269,16 @@ ai:
   model_profile: "medium"         # small | medium | large
 
 # ── Compute environment ─────────────────────────────────────────────────
+# The AI fills these from how you actually run things and consults them
+# before launching work: which env to activate, whether a job counts as
+# "long-running", whether to offer a Slurm submission. Keep accurate so
+# reproduction + scheduling decisions are right. (Project deps live in
+# environment/requirements.txt — import-driven, NOT the research-os stack.)
 runtime:
   shared_server: false           # set true on HPC / shared boxes
   long_running_threshold_seconds: 60
+  compute_environment: ""        # e.g. "conda env: myproj" / "module load cuda/12" / "docker: myimg"
+  package_manager: ""            # pip | conda | uv | poetry  (blank → AI infers)
 
 # ── Figure defaults ────────────────────────────────────────────────────
 # What companions the AI ships with every figure. SVG companions double

--- a/src/research_os/tools/actions/state/context_watch.py
+++ b/src/research_os/tools/actions/state/context_watch.py
@@ -1,0 +1,129 @@
+"""Live context drop-zone detection.
+
+``inputs/context/`` (and each step's ``context/``) is a free drop-zone:
+the researcher can drop a paper, a screenshot, a txt note, a PI email —
+anything — at ANY point, even mid-session, then say "I put something in
+context". The AI must notice and read it.
+
+``detect_new_context`` compares the current context files against a
+small marker (``.os_state/context_seen.json``) and reports what's NEW or
+CHANGED since the last turn. sys_boot peeks (``update_marker=False``);
+tool_route consumes (``update_marker=True``) so each drop is surfaced
+once, on the next prompt after it lands.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger("research_os.context_watch")
+
+_MARKER = ".os_state/context_seen.json"
+_MAX_REPORT = 12
+
+
+def _context_dirs(root: Path) -> list[Path]:
+    dirs = [root / "inputs" / "context"]
+    ws = root / "workspace"
+    if ws.exists():
+        for d in sorted(ws.iterdir()):
+            c = d / "context"
+            if c.is_dir():
+                dirs.append(c)
+    return dirs
+
+
+def _snapshot(root: Path) -> dict[str, list[int]]:
+    """Map rel-path → [size, mtime] for every researcher-dropped context
+    file (skips our auto-seed READMEs and dotfiles)."""
+    out: dict[str, list[int]] = {}
+    for base in _context_dirs(root):
+        if not base.exists():
+            continue
+        for p in base.rglob("*"):
+            if not p.is_file():
+                continue
+            if p.name == "README.md" or p.name.startswith("."):
+                continue
+            try:
+                st = p.stat()
+                rel = str(p.relative_to(root))
+            except (OSError, ValueError):
+                continue
+            out[rel] = [int(st.st_size), int(st.st_mtime)]
+    return out
+
+
+def detect_new_context(root: Path, *, update_marker: bool = True) -> dict[str, Any]:
+    """Report context files added / changed since the last seen snapshot.
+
+    Returns ``{new_files, changed_files, hint, first_scan}``. On the very
+    first scan (no marker yet) it establishes a baseline and reports
+    nothing — the initial briefing docs are handled by intake, not flagged
+    as a surprise drop.
+    """
+    root = Path(root)
+    current = _snapshot(root)
+    marker = root / _MARKER
+    first = not marker.exists()
+    prior: dict[str, list[int]] = {}
+    if not first:
+        try:
+            loaded = json.loads(marker.read_text())
+            if isinstance(loaded, dict):
+                prior = loaded
+        except (OSError, ValueError):
+            prior = {}
+
+    new_files: list[str] = []
+    changed_files: list[str] = []
+    if not first:
+        for rel, sig in sorted(current.items()):
+            if rel not in prior:
+                new_files.append(rel)
+            elif prior[rel] != sig:
+                changed_files.append(rel)
+
+    if update_marker:
+        try:
+            marker.parent.mkdir(parents=True, exist_ok=True)
+            marker.write_text(json.dumps(current, sort_keys=True) + "\n")
+        except OSError as e:
+            logger.debug("context marker write skipped: %s", e)
+
+    hint = ""
+    if new_files or changed_files:
+        shown = (new_files + changed_files)[:_MAX_REPORT]
+        hint = (
+            f"{len(new_files)} new + {len(changed_files)} changed file(s) in "
+            "context/ since last turn — the researcher dropped material for "
+            "you. READ them (sys_file_read) before proceeding and fold "
+            "anything relevant into the current step's plan / analysis: "
+            + ", ".join(shown)
+        )
+    return {
+        "new_files": new_files,
+        "changed_files": changed_files,
+        "hint": hint,
+        "first_scan": first,
+    }
+
+
+def glossary_unfilled(root: Path) -> bool:
+    """True if docs/glossary.md exists but has no data rows (header only).
+
+    The reaction-similarity project shipped an empty glossary; this lets
+    sys_boot nudge the AI to populate domain terms it encounters.
+    """
+    g = Path(root) / "docs" / "glossary.md"
+    if not g.exists():
+        return False
+    try:
+        txt = g.read_text()
+    except OSError:
+        return False
+    rows = [ln for ln in txt.splitlines() if ln.strip().startswith("|")]
+    # header row + separator row = 2; any real term adds a 3rd.
+    return len(rows) <= 2

--- a/src/research_os/tools/actions/state/path.py
+++ b/src/research_os/tools/actions/state/path.py
@@ -420,36 +420,16 @@ def workflow_dag(
                     if edge not in edges:
                         edges.append(edge)
 
-        # Build mermaid.
+        # Build mermaid via the SHARED builder so docs/workflow_dag.mermaid
+        # and workspace/workflow.mermaid never drift (rich DAG: real data-
+        # dependency edges, statuses, per-step purpose, dead-ends, branches).
         out_dir = root / output_dir
         out_dir.mkdir(parents=True, exist_ok=True)
-        mermaid_lines = [
-            "graph TD",
-            "    classDef active fill:#fff3cd,stroke:#856404,color:#333",
-            "    classDef completed fill:#d4edda,stroke:#28a745,color:#155724",
-            "    classDef dead_end fill:#f8d7da,stroke:#dc3545,color:#721c24",
-        ]
-        # Stable iteration order (numbered).
-        for pid in sorted(nodes):
-            node = nodes[pid]
-            safe_id = re.sub(r"[^A-Za-z0-9_]", "_", pid)
-            mermaid_lines.append(
-                f'    {safe_id}["{node["label"]}"]:::{node["status"]}'
-            )
-        if not edges:
-            # Show ingest from inputs/raw_data for the first step at least.
-            first = sorted(nodes)[0]
-            safe_first = re.sub(r"[^A-Za-z0-9_]", "_", first)
-            mermaid_lines.append("    raw[\"inputs/raw_data\"]")
-            mermaid_lines.append(f"    raw --> {safe_first}")
-        else:
-            for src, dst in edges:
-                src_safe = re.sub(r"[^A-Za-z0-9_]", "_", src)
-                dst_safe = re.sub(r"[^A-Za-z0-9_]", "_", dst)
-                mermaid_lines.append(f"    {src_safe} --> {dst_safe}")
+        from research_os.project_ops import _build_workflow_mermaid
 
+        mermaid_text = _build_workflow_mermaid(root)
         mmd_path = out_dir / "workflow_dag.mermaid"
-        mmd_path.write_text("\n".join(mermaid_lines) + "\n")
+        mmd_path.write_text(mermaid_text + "\n")
 
         png_path: str | None = None
         png_renderer = None  # mmdc | matplotlib | None

--- a/src/research_os/wizard.py
+++ b/src/research_os/wizard.py
@@ -264,6 +264,7 @@ def run_wizard(args) -> WizardResult:
     workspace_mode = _ask_workspace_mode(getattr(args, "workspace_mode", None))
     ok({
         "analysis":    "Mode: analysis (linear analysis steps)",
+        "hybrid":      "Mode: hybrid (research + software component)",
         "tool_build":  "Mode: tool_build (governed software build)",
         "exploration": "Mode: exploration (scratch-first probes)",
         "notebook":    "Mode: notebook (Jupyter-first)",
@@ -419,6 +420,7 @@ def run_wizard(args) -> WizardResult:
 
 VALID_WORKSPACE_MODES = (
     "analysis", "tool_build", "exploration", "notebook", "multi_study",
+    "hybrid",
 )
 
 
@@ -435,6 +437,7 @@ def _ask_workspace_mode(preset: str | None = None) -> str:
         "What are you building?",
         [
             ("analysis",    "Analysis pipeline (data → results → paper)"),
+            ("hybrid",      "Research + software (analysis steps + a code component)"),
             ("tool_build",  "A tool / software I iterate on"),
             ("exploration", "Quick exploration (scratch-first probes)"),
             ("notebook",    "A Jupyter notebook project"),

--- a/src/research_os/wizard.py
+++ b/src/research_os/wizard.py
@@ -138,8 +138,11 @@ class WizardResult:
     # Model tier — written into researcher_config.yaml as model_profile.
     model_profile: str = "medium"
     # Workspace mode — written into researcher_config.yaml as workspace.mode.
-    #   analysis (default) | tool_build | exploration
+    #   analysis (default) | hybrid | tool_build | exploration | notebook | multi_study
     workspace_mode: str = "analysis"
+    # MCP registration scope: workspace (per-project files, default) or
+    # global (also print the user-scope install command).
+    mcp_scope: str = "workspace"
     # Researcher identity, written into researcher_config.yaml AND
     # (when researcher opts in) ~/.config/research-os/profile.yaml so
     # the next `research-os init` pre-fills these without asking.
@@ -405,6 +408,7 @@ def run_wizard(args) -> WizardResult:
         api_keys=api_keys,
         model_profile=model_profile,
         workspace_mode=workspace_mode,
+        mcp_scope=(getattr(args, "mcp_scope", None) or "workspace"),
         researcher_name=researcher_name,
         researcher_email=researcher_email,
         researcher_institution=researcher_institution,
@@ -807,6 +811,15 @@ def _next_steps(r: WizardResult) -> None:
     print(f"        {_C.DIM}inputs/context/{_C.RESET}      notes, drafts, screenshots, prior reports")
     n += 1
     print(f"  {_C.CYAN}{n}.{_C.RESET}  Open your AI IDE on this folder — the MCP server auto-launches.")
+    print(f"        {_C.BOLD}⚠ Already have it open? RESTART the IDE / reload the window{_C.RESET}")
+    print(f"        {_C.DIM}so the research-os MCP tools load — they won't appear until you do.{_C.RESET}")
+    if getattr(r, "mcp_scope", "workspace") == "global":
+        try:
+            from research_os.project_ops import mcp_global_install_hint
+            for line in mcp_global_install_hint(r.ides).splitlines():
+                print(f"        {_C.DIM}{line}{_C.RESET}")
+        except Exception:
+            pass
     n += 1
     print(f"  {_C.CYAN}{n}.{_C.RESET}  Start chatting. Try:")
     for line in [

--- a/templates/.claude/rules/research-os.md
+++ b/templates/.claude/rules/research-os.md
@@ -35,7 +35,7 @@ continue an in-flight plan via `tool_plan(operation="advance")`).
 Tools use underscores: `sys_state_get`, `tool_data`,
 `mem_log`. Dot notation + legacy aliases auto-rewrite.
 
-Never write to `inputs/raw_data/` or `inputs/literature/` (immutable).
+Treat `inputs/raw_data/` + `inputs/literature/` as source-of-truth: edit only with `force=true` + researcher OK (soft guard). `inputs/context/` is a free drop-zone. `.os_state/` is never hand-edited.
 All workspace I/O goes through MCP tools.
 
 **Workspace modes.** `sys_boot` reports `workspace_mode`. It shapes what

--- a/templates/.cursor/rules/research-os.mdc
+++ b/templates/.cursor/rules/research-os.mdc
@@ -40,7 +40,7 @@ straight to `tool_route` (or continue an in-flight plan).
 Tools use underscores: `sys_state_get`, `tool_data`,
 `mem_log`. Dot notation + legacy aliases auto-rewrite.
 
-Never write to `inputs/raw_data/` or `inputs/literature/` (immutable).
+Treat `inputs/raw_data/` + `inputs/literature/` as source-of-truth: edit only with `force=true` + researcher OK (soft guard). `inputs/context/` is a free drop-zone. `.os_state/` is never hand-edited.
 All workspace I/O goes through MCP tools.
 
 **Workspace modes.** `sys_boot` reports `workspace_mode`. It shapes what

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -194,6 +194,14 @@ unit of work" and "done" mean — let it steer routing:
   `tool_bash_exec` for anything else, and `tool_task` for long builds.
 * **exploration** — scratch-first. `workspace/scratch/` is home base;
   gates are light; promote a probe to a numbered step only when it earns it.
+* **hybrid** — research + software. Routes + scaffolds like **analysis**
+  (numbered research steps), but the project ALSO ships code: `sys_boot`
+  reports `software_components` (inner repos / packages it detected), and
+  the workflow DAG shows each as a `Software` node the research "informs".
+  Govern BOTH sides — the research in `workspace/NN_*` steps (figures +
+  conclusions), and the code in the inner repo via `tool_git` + `tool_build`
+  + `tool_audit(scope="tool")`. The reaction-similarity shape: characterise
+  a method across steps, then implement it as a library.
 
 ---
 

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -128,6 +128,18 @@ every session, and MAINTAIN them:
   `interaction.agent_notes`. Never silently override a value the researcher
   set by hand — confirm first if it conflicts.
 
+**Watch the context drop-zone.** The researcher can drop a paper, a
+screenshot, a txt note, a PI email into `inputs/context/` (or a step's
+`context/`) at ANY time — even mid-session. `sys_boot.new_context` and
+`tool_route`'s `new_context` field surface files added/changed since the
+last turn: when they appear, `sys_file_read` them and fold anything
+relevant into the current step's plan / analysis before continuing.
+
+**Keep the glossary alive.** When you introduce a domain term the
+researcher's collaborators (or a future reader) might not know, add a row
+to `docs/glossary.md` (`term | definition | source`). `sys_boot.glossary_unfilled`
+nudges when it's still empty after real work has happened.
+
 **Never load `_router_index.yaml` directly.** That file is a maintainer
 artifact — the routing logic reads it server-side. For routing, call
 `tool_route`. For ranked alternatives, call `tool_semantic_route`. For

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -112,6 +112,22 @@ fires, explain WHY it exists before offering the fix. Run
 `tool_lessons(operation="mistake_replay")` at session start to surface
 recurring patterns from the researcher's reliability + override logs.
 
+**Your operating contract — keep `researcher_config.yaml` in sync.**
+`inputs/researcher_config.yaml` is your secondary AGENTS.md. `sys_boot`
+surfaces it as `config_directives` (+ a `config_reconcile_hint`). FOLLOW
+those values (autonomy, quality_gate_policy, ambiguity_posture, agent_notes)
+every session, and MAINTAIN them:
+
+* **At startup**, reconcile the config with the researcher's stated goal —
+  if they name a deliverable ("a paper", "a dashboard"), set
+  `research_goal.output_types`; record the env in `runtime.compute_environment`.
+* **On any intent shift**, update it via `sys_config(operation='set', …)`:
+  "just be autonomous" → `interaction.autonomy_level=autopilot`; "we're
+  submitting to Nature" → `output_types` + `writing_preferences.venue_template`
+  + `citation_style`; project-specific rules → append to
+  `interaction.agent_notes`. Never silently override a value the researcher
+  set by hand — confirm first if it conflicts.
+
 **Never load `_router_index.yaml` directly.** That file is a maintainer
 artifact — the routing logic reads it server-side. For routing, call
 `tool_route`. For ranked alternatives, call `tool_semantic_route`. For
@@ -198,7 +214,12 @@ unit of work" and "done" mean — let it steer routing:
 
 ## Hard rules (NEVER violate)
 
-1. **Never write to `inputs/raw_data/` or `inputs/literature/`** — immutable.
+1. **`.os_state/` is never hand-edited** (internal state). `inputs/` is the
+   researcher's source-of-truth and is editable — but `inputs/raw_data/` +
+   `inputs/literature/` are the ORIGINAL record: change them only with
+   `force=true` + the researcher's OK (the write warns + flags the intake
+   inventory stale). `inputs/context/` is a free drop-zone — write there
+   freely.
 2. **Never invent citations.** All final-deliverable citations are
    verified via `tool_citations_verify` (Crossref / Semantic Scholar /
    PubMed / arXiv); `tool_synthesis_check` surfaces unresolved keys
@@ -286,11 +307,12 @@ authorises a bypass — words like "skip the audit", "just draft it",
 * The override is never permanent — the next deliverable call re-runs
   the gate. The researcher must re-authorise each bypass.
 
-If the researcher's request would force a violation of a Hard Rule
-that is NOT a quality gate (e.g. invent a citation, write to
-`inputs/raw_data/`), refuse and explain the constraint. The hard
-rules above are absolute; the quality gate is the only authorised
-escape hatch.
+If the researcher's request would force a violation of a Hard Rule that
+is NOT a quality gate (e.g. invent a citation, hand-edit `.os_state/`),
+refuse and explain the constraint. Editing original inputs
+(`inputs/raw_data/` + `inputs/literature/`) is NOT absolute — it's a soft
+guard: proceed with `force=true` once the researcher confirms, and note
+the intake inventory is now stale.
 
 Research OS does **not** manage LLM provider keys. The IDE owns model
 access. The only credentials it uses are for literature / web search.

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -46,6 +46,24 @@ Need to confirm which project the server resolved for THIS request?
 Call `sys_active_project` — it returns the resolved root + how it
 was resolved (env var / cwd walk / fallback).
 
+**Setting up a new project (when the researcher asks).** Do NOT run
+`research-os init` blindly with defaults. INTERVIEW first — ask the few
+questions that change the scaffold + how you'll work, in one short batch:
+
+* the **research question / goal** (and whether it's research, software,
+  or **hybrid** — research + a code deliverable);
+* the **domain**;
+* what they want to **produce** (paper / dashboard / poster / report, or
+  "just exploring") → `research_goal.output_types`;
+* how **autonomous** you should be → `interaction.autonomy_level`;
+* the **compute environment** (laptop / HPC / which conda env) →
+  `runtime.compute_environment`.
+
+Fold the answers into `inputs/researcher_config.yaml` (your operating
+contract). THEN scaffold. After MCP is wired, **tell the researcher to
+restart their IDE / session** — the `research-os` tools will not appear in
+the current session until they reload.
+
 ---
 
 ## Every session — boot in two MCP calls (first turn only)

--- a/templates/CLAUDE.md
+++ b/templates/CLAUDE.md
@@ -31,7 +31,7 @@ Tools use underscores (`sys_state_get`, `tool_data`, `mem_log`). Dot
 notation and legacy names auto-rewrite. Need the full description of a
 tool? `sys_tool_describe(tool_name)`.
 
-Never write to `inputs/raw_data/` or `inputs/literature/` (immutable).
+Treat `inputs/raw_data/` + `inputs/literature/` as source-of-truth: edit only with `force=true` + researcher OK (soft guard). `inputs/context/` is a free drop-zone. `.os_state/` is never hand-edited.
 All workspace I/O goes through `sys_file_*` so provenance is captured.
 
 **Workspace modes.** `sys_boot` reports `workspace_mode` (analysis /

--- a/templates/researcher_config.yaml
+++ b/templates/researcher_config.yaml
@@ -57,13 +57,23 @@ workspace:
     test: ""              # e.g. "pytest -q" | "cargo test" | "npm test"
     lint: ""              # e.g. "ruff check ." | "cargo clippy" | "eslint ."
 
-# ── What you want to produce (blank = AI suggests; start exploratory) ───
+# ── What you want to produce ────────────────────────────────────────────
+# Blank output_types = EXPLORATORY: the AI will NOT auto-build a paper /
+# dashboard / poster you didn't ask for (synthesis gates on this). You
+# don't have to decide up front. The AI fills this in from your goal —
+# say "we're submitting to Nature" and it sets output_types + target_venue
+# + writing_preferences.* and keeps them in sync as the goal shifts.
 research_goal:
   output_types: []               # paper | abstract | poster | dashboard | report | exploratory
   target_venue: ""               # journal | conference | preprint | dissertation | report
   poster_dimensions: "36x48"
 
-# ── How the AI should behave ────────────────────────────────────────────
+# ── How the AI should behave — the AI's operating contract ──────────────
+# Treat this block as a secondary AGENTS.md. The AI READS it every session
+# (via sys_boot) and FOLLOWS it, and it KEEPS IT IN SYNC with what you ask:
+# say "just be autonomous" → it sets autonomy_level: autopilot; "ask before
+# big moves" → supervised; "teach me as we go" → coaching. It never
+# silently overrides a value you set by hand.
 interaction:
   autonomy_level: "supervised"   # manual | supervised | autopilot | coaching
   # coaching → AI doesn't auto-execute; surfaces pedagogical preludes,
@@ -85,6 +95,13 @@ interaction:
   #   ask_when_uncertain → default; AI asks a one-line follow-up
   #   take_best_default  → AI proceeds, surfaces the chosen default for review
   ambiguity_posture: "ask_when_uncertain"
+
+  # Free-form, project-specific directives the AI records + obeys — the
+  # "how to act on THIS project" notes that don't fit a knob above (e.g.
+  # "always segregate transport reactions", "prefer DRFP over structural
+  # fingerprints", "never touch the prod DB"). The AI appends here as it
+  # learns your preferences; edit by hand any time.
+  agent_notes: ""
 
 # ── Audit strictness ───────────────────────────────────────────────────
 # How hard audits enforce gates. "light" downgrades most blockers to
@@ -179,9 +196,16 @@ ai:
   model_profile: "medium"         # small | medium | large
 
 # ── Compute environment ─────────────────────────────────────────────────
+# The AI fills these from how you actually run things and consults them
+# before launching work: which env to activate, whether a job counts as
+# "long-running", whether to offer a Slurm submission. Keep accurate so
+# reproduction + scheduling decisions are right. (Project deps live in
+# environment/requirements.txt — import-driven, NOT the research-os stack.)
 runtime:
   shared_server: false           # set true on HPC / shared boxes
   long_running_threshold_seconds: 60
+  compute_environment: ""        # e.g. "conda env: myproj" / "module load cuda/12" / "docker: myimg"
+  package_manager: ""            # pip | conda | uv | poetry  (blank → AI infers)
 
 # ── Figure defaults ────────────────────────────────────────────────────
 # What companions the AI ships with every figure. SVG companions double

--- a/tests/tools/test_iteration.py
+++ b/tests/tools/test_iteration.py
@@ -830,6 +830,13 @@ def test_finalize_env_snapshot_uses_project_scope(tmp_path):
     (step_dir / "outputs" / "figures").mkdir(parents=True, exist_ok=True)
     (step_dir / "outputs" / "figures" / "01_fake.png").write_bytes(b"\x89PNG\r\n\x1a\n")
     (step_dir / "outputs" / "figures" / "01_fake.caption.md").write_text("caption.")
+    # A real analysis script that imports a third-party package the test
+    # env has installed (yaml = PyYAML). The import-driven snapshot must
+    # pin it; it must NOT leak the research_os server stack.
+    (step_dir / "scripts").mkdir(parents=True, exist_ok=True)
+    (step_dir / "scripts" / "01a_run.py").write_text(
+        "import yaml\nimport json\nprint(yaml.__name__)\n"
+    )
     conc = step_dir / "conclusions.md"
     conc.write_text(
         "# Conclusions\n## Decision\nPROCEED.\n## Findings\n- All good.\n"
@@ -837,16 +844,23 @@ def test_finalize_env_snapshot_uses_project_scope(tmp_path):
     finalize_path(step["path_id"], tmp_path)
     proj_req = tmp_path / "environment" / "requirements.txt"
     text = proj_req.read_text()
-    # Post-snapshot, the file should have at least one non-comment
-    # package line (e.g. 'pytest==X.Y' or similar).
-    has_package = any(
-        ln.strip() and not ln.strip().startswith("#")
+    pkg_lines = [
+        ln.strip().lower()
         for ln in text.splitlines()
+        if ln.strip() and not ln.strip().startswith("#")
+    ]
+    # The project's actual import is pinned…
+    assert any(ln.startswith("pyyaml==") for ln in pkg_lines), (
+        "import-driven requirements.txt should pin the project's own imports "
+        f"(expected PyYAML from `import yaml`); got:\n{text}"
     )
-    assert has_package, (
-        "project environment/requirements.txt should have pinned packages "
-        "after finalize, not stay as the comment-only template"
-    )
+    # …and the Research-OS server stack is excluded (the bug this fixes).
+    assert not any(
+        ln.startswith(("research_os", "research-os", "mcp==", "fastembed"))
+        for ln in pkg_lines
+    ), f"requirements.txt must NOT contain the research_os server stack; got {pkg_lines}"
+    # stdlib imports are never pinned.
+    assert not any(ln.startswith("json==") for ln in pkg_lines)
 
 
 def test_tools_md_filters_stdlib(tmp_path):

--- a/tests/unit/test_context_watch.py
+++ b/tests/unit/test_context_watch.py
@@ -1,0 +1,67 @@
+"""3.2.2 — live context drop-zone detection + glossary nudge.
+
+inputs/context/ (and per-step context/) is a free drop-zone the researcher
+fills at any time. detect_new_context surfaces NEW/CHANGED files since the
+last seen snapshot; the first scan establishes a baseline silently.
+"""
+from __future__ import annotations
+
+from research_os.project_ops import scaffold_minimal_workspace
+from research_os.tools.actions.state.context_watch import (
+    detect_new_context,
+    glossary_unfilled,
+)
+
+
+def test_first_scan_is_silent_baseline(tmp_path):
+    scaffold_minimal_workspace(tmp_path, "Demo", ide_flags=[], copy_agents=False)
+    (tmp_path / "inputs" / "context" / "brief.md").write_text("project brief")
+    res = detect_new_context(tmp_path, update_marker=True)
+    assert res["first_scan"] is True
+    assert res["new_files"] == [] and res["changed_files"] == []
+
+
+def test_new_drop_detected_after_baseline(tmp_path):
+    scaffold_minimal_workspace(tmp_path, "Demo", ide_flags=[], copy_agents=False)
+    (tmp_path / "inputs" / "context" / "brief.md").write_text("project brief")
+    detect_new_context(tmp_path, update_marker=True)  # baseline
+    # Researcher drops a paper mid-session.
+    (tmp_path / "inputs" / "context" / "paper.txt").write_text("a dropped paper")
+    res = detect_new_context(tmp_path, update_marker=True)
+    assert "inputs/context/paper.txt" in res["new_files"]
+    assert "context/" in res["hint"] and "READ them" in res["hint"]
+    # Consumed: a second scan with no change reports nothing.
+    res2 = detect_new_context(tmp_path, update_marker=True)
+    assert res2["new_files"] == [] and res2["changed_files"] == []
+
+
+def test_peek_does_not_consume(tmp_path):
+    scaffold_minimal_workspace(tmp_path, "Demo", ide_flags=[], copy_agents=False)
+    detect_new_context(tmp_path, update_marker=True)  # baseline
+    (tmp_path / "inputs" / "context" / "note.md").write_text("note")
+    peek = detect_new_context(tmp_path, update_marker=False)
+    assert "inputs/context/note.md" in peek["new_files"]
+    # Still reported on the next (consuming) call because peek didn't mark it.
+    consume = detect_new_context(tmp_path, update_marker=True)
+    assert "inputs/context/note.md" in consume["new_files"]
+
+
+def test_readme_seed_not_flagged(tmp_path):
+    scaffold_minimal_workspace(tmp_path, "Demo", ide_flags=[], copy_agents=False)
+    detect_new_context(tmp_path, update_marker=True)
+    (tmp_path / "inputs" / "context" / "README.md").write_text("# seed changed")
+    res = detect_new_context(tmp_path, update_marker=True)
+    assert res["new_files"] == [] and res["changed_files"] == []
+
+
+def test_glossary_unfilled(tmp_path):
+    scaffold_minimal_workspace(tmp_path, "Demo", ide_flags=[], copy_agents=False)
+    g = tmp_path / "docs" / "glossary.md"
+    g.parent.mkdir(parents=True, exist_ok=True)
+    g.write_text("# Glossary\n\n| Term | Definition | Source |\n|---|---|---|\n")
+    assert glossary_unfilled(tmp_path) is True
+    g.write_text(
+        "# Glossary\n\n| Term | Definition | Source |\n|---|---|---|\n"
+        "| DRFP | reaction fingerprint | Probst 2022 |\n"
+    )
+    assert glossary_unfilled(tmp_path) is False

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -60,17 +60,21 @@ def test_path_create_creates_full_subtree():
         exp = root / "workspace" / res["path_id"]
         assert exp.exists()
         # Per-step subdirs — note: NO outputs/dashboards (dashboards are
-        # synthesis-level, not per-step).
+        # synthesis-level, not per-step) and NO outputs/reports (created on
+        # demand only — see EXPERIMENT_SUBDIRS note in project_ops).
         for sub in ("scripts", "literature",
                     "data/past_step_input", "data/next_step_output", "data/share",
-                    "outputs/reports", "outputs/figures", "outputs/tables",
+                    "outputs/figures", "outputs/tables",
                     "environment"):
             assert (exp / sub).exists(), sub
         # plan.md is written at step creation (pre-step planning).
         assert (exp / "plan.md").exists()
-        # Confirm no per-step dashboards folder.
+        # Confirm no per-step dashboards folder, and reports/ is NOT
+        # pre-created (it's a magnet for misplaced artefacts otherwise).
         assert not (exp / "outputs" / "dashboards").exists(), \
             "outputs/dashboards should not be created per-step"
+        assert not (exp / "outputs" / "reports").exists(), \
+            "outputs/reports should be created on demand, not pre-seeded"
         assert (exp / "README.md").exists()
         assert (exp / "conclusions.md").exists()
 

--- a/tests/unit/test_mcp_setup_canonical.py
+++ b/tests/unit/test_mcp_setup_canonical.py
@@ -1,0 +1,43 @@
+"""3.2.2 — one canonical MCP entry + Claude Code root .mcp.json + restart notice."""
+from __future__ import annotations
+
+from research_os.project_ops import (
+    _setup_mcp_configs,
+    mcp_global_install_hint,
+    mcp_restart_notice,
+    mcp_server_entry,
+)
+
+
+def test_entry_is_portable():
+    e = mcp_server_entry()
+    assert e["command"] == "research-os"
+    assert e["args"] == ["start"]
+    # Portable workspace hint — never an absolute path.
+    assert e["env"]["RESEARCH_OS_WORKSPACE"] == "${workspaceFolder}"
+
+
+def test_claude_writes_canonical_root_mcp_json(tmp_path):
+    (tmp_path / ".os_state").mkdir()
+    _setup_mcp_configs(tmp_path, ["claude"])
+    import json
+
+    root_mcp = tmp_path / ".mcp.json"
+    claude_mcp = tmp_path / ".claude" / "mcp.json"
+    assert root_mcp.exists(), "Claude Code reads ROOT .mcp.json — must be written"
+    assert claude_mcp.exists()
+    a = json.loads(root_mcp.read_text())["mcpServers"]["research-os"]
+    b = json.loads(claude_mcp.read_text())["mcpServers"]["research-os"]
+    # Both carry the identical canonical entry (no drift).
+    assert a == b == mcp_server_entry()
+
+
+def test_restart_notice_is_loud():
+    n = mcp_restart_notice()
+    assert "RESTART" in n.upper()
+
+
+def test_global_hint_mentions_user_scope():
+    hint = mcp_global_install_hint(["claude", "cursor"])
+    assert "global" in hint.lower() or "user scope" in hint.lower()
+    assert "claude mcp add" in hint

--- a/tests/unit/test_plan_md_living.py
+++ b/tests/unit/test_plan_md_living.py
@@ -44,6 +44,64 @@ def test_finalize_nudges_when_plan_not_updated(tmp_path):
     ), f"expected a plan.md reconcile nudge; got {res.get('warnings')}"
 
 
+def test_next_step_blocked_when_plan_is_unfilled_seed(tmp_path):
+    """The predecessor gate must refuse to scaffold step N+1 when step N's
+    plan.md is still the raw seed — the exact failure seen in the
+    reaction-similarity project (all steps shipped an untouched plan.md
+    yet still advanced)."""
+    import pytest
+
+    scaffold_minimal_workspace(tmp_path, "Test", ide_flags=[], copy_agents=False)
+    sid = create_numbered_experiment(
+        tmp_path, "eda", enforce_predecessor_finalized=False,
+    )["path_id"]
+    step = tmp_path / "workspace" / sid
+    # Fill README + conclusions so ONLY plan.md is the blocker — proving the
+    # gate now inspects plan.md specifically.
+    (step / "README.md").write_text(
+        "# Experiment\n## In plain English\nWe did a real thing.\n"
+        "## Input data\n- data.csv\n## Methods (one line each)\n- a method\n"
+        "## Headline finding\n- a real headline\n## Decision\n- proceed\n"
+    )
+    (step / "conclusions.md").write_text(
+        "## Findings\n- a real finding.\n## Decision\nPROCEED.\n"
+    )
+    # plan.md left as the unfilled seed.
+    with pytest.raises(ValueError, match="plan.md"):
+        create_numbered_experiment(
+            tmp_path, "model", enforce_predecessor_finalized=True,
+        )
+
+
+def test_next_step_allowed_when_plan_filled(tmp_path):
+    """A genuinely-written plan.md lets the next step scaffold."""
+    scaffold_minimal_workspace(tmp_path, "Test", ide_flags=[], copy_agents=False)
+    sid = create_numbered_experiment(
+        tmp_path, "eda", enforce_predecessor_finalized=False,
+    )["path_id"]
+    step = tmp_path / "workspace" / sid
+    (step / "README.md").write_text(
+        "# Experiment\n## In plain English\nWe did a real thing.\n"
+        "## Input data\n- data.csv\n## Methods (one line each)\n- a method\n"
+        "## Headline finding\n- a real headline\n## Decision\n- proceed\n"
+    )
+    (step / "conclusions.md").write_text(
+        "## Findings\n- a real finding.\n## Decision\nPROCEED.\n"
+    )
+    (step / "plan.md").write_text(
+        "# Plan\n## Where we are\nFirst step on the BERDL data.\n"
+        "## What this step will do\nProfile the molecules table.\n"
+        "## Why this step, why now\nWe need the shape before modelling.\n"
+        "## Open questions for the researcher\nWhich cutoff?\n"
+        "## Progress & deviations from plan\nWent to plan.\n"
+        "## Anticipated next steps\nSimilarity characterization.\n"
+    )
+    res = create_numbered_experiment(
+        tmp_path, "model", enforce_predecessor_finalized=True,
+    )
+    assert res["path_id"].endswith("_model")
+
+
 def test_finalize_quiet_when_plan_reconciled(tmp_path):
     step, sid = _step(tmp_path)
     plan = (step / "plan.md").read_text()

--- a/tests/unit/test_sys_file_path_traversal.py
+++ b/tests/unit/test_sys_file_path_traversal.py
@@ -116,6 +116,9 @@ class TestSysFileWrite:
         assert "protect" in msg or "read-only" in msg
 
     def test_inputs_raw_data_blocked(self, tmp_path):
+        # 3.2.2: original inputs are SOFT-guarded — a plain write (no force)
+        # is still refused, but with a "pass force=true" hint, not a hard
+        # write-protection error.
         root = _make_project(tmp_path)
         resp = _handle_sys_file_write(
             "sys_file_write",
@@ -124,6 +127,34 @@ class TestSysFileWrite:
         )
         body = _payload(resp)
         assert body["status"] == "error"
+        assert "force=true" in (body.get("error") or "")
+
+    def test_inputs_raw_data_allowed_with_force(self, tmp_path):
+        # 3.2.2: force=true lets the AI edit original inputs (with a warning).
+        root = _make_project(tmp_path)
+        resp = _handle_sys_file_write(
+            "sys_file_write",
+            {"filepath": "inputs/raw_data/x.csv", "content": "a,b\n1,2",
+             "force": True},
+            root,
+        )
+        body = _payload(resp)
+        assert body["status"] == "success"
+        assert (root / "inputs" / "raw_data" / "x.csv").read_text() == "a,b\n1,2"
+        warning = (body.get("data") or {}).get("warning") or body.get("warning") or ""
+        assert "provenance" in warning.lower()
+
+    def test_inputs_context_allowed_freely(self, tmp_path):
+        # 3.2.2: inputs/context is a free drop-zone — no force needed.
+        root = _make_project(tmp_path)
+        resp = _handle_sys_file_write(
+            "sys_file_write",
+            {"filepath": "inputs/context/note.md", "content": "a thought"},
+            root,
+        )
+        body = _payload(resp)
+        assert body["status"] == "success"
+        assert (root / "inputs" / "context" / "note.md").read_text() == "a thought"
 
     def test_workspace_allowed(self, tmp_path):
         root = _make_project(tmp_path)

--- a/tests/unit/test_workflow_mermaid_rich.py
+++ b/tests/unit/test_workflow_mermaid_rich.py
@@ -1,0 +1,62 @@
+"""3.2.2 — the workflow mermaid is a real data-dependency DAG.
+
+The old generator hung every step off a synthetic `init` node with no
+real edges (the reaction-similarity project shipped exactly that). The
+rich builder derives edges from data symlinks / sequential fallback,
+labels nodes with status + a one-line purpose, and styles dead-ends.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from research_os.project_ops import (
+    _build_workflow_mermaid,
+    create_numbered_experiment,
+    scaffold_minimal_workspace,
+)
+
+
+def _fill(step_dir: Path, goal: str) -> None:
+    (step_dir / "README.md").write_text(
+        f"# E\n## Goal\n{goal}\n## In plain English\nx\n## Input data\n- d\n"
+        "## Methods (one line each)\n- m\n## Headline finding\n- h\n"
+        "## Decision\n- proceed\n"
+    )
+    (step_dir / "conclusions.md").write_text("## Findings\n- f\n## Decision\nPROCEED\n")
+    (step_dir / "plan.md").write_text(
+        "## Where we are\na\n## What this step will do\nb\n"
+        "## Why this step, why now\nc\n## Open questions for the researcher\nd\n"
+        "## Progress & deviations from plan\ne\n## Anticipated next steps\nf\n"
+    )
+
+
+def test_mermaid_is_real_dag_not_init_fanout(tmp_path):
+    scaffold_minimal_workspace(tmp_path, "Demo", ide_flags=[], copy_agents=False)
+    s1 = create_numbered_experiment(
+        tmp_path, "biochem intake", enforce_predecessor_finalized=False
+    )["path_id"]
+    _fill(tmp_path / "workspace" / s1, "Profile the molecules table for QC")
+    s2 = create_numbered_experiment(
+        tmp_path, "profiling", enforce_predecessor_finalized=True
+    )["path_id"]
+    _fill(tmp_path / "workspace" / s2, "Characterize similarity")
+
+    mer = _build_workflow_mermaid(tmp_path)
+    # No synthetic init fan-out.
+    assert "init -->" not in mer
+    assert "init[" not in mer
+    # Real sequential edge between the two steps.
+    assert f"{s1.replace('-', '_')} --> {s2.replace('-', '_')}" in mer
+    # Raw-data source node + ingest edge for the first step.
+    assert "inputs/raw_data" in mer and f"raw --> {s1}" in mer
+    # Purpose label is surfaced.
+    assert "Profile the molecules table for QC" in mer
+    # Status classes present.
+    assert "classDef completed" in mer and "classDef dead_end" in mer
+
+
+def test_mermaid_empty_project_is_safe(tmp_path):
+    scaffold_minimal_workspace(tmp_path, "Demo", ide_flags=[], copy_agents=False)
+    mer = _build_workflow_mermaid(tmp_path)
+    assert mer.startswith("graph TD")
+    assert "No analysis steps yet" in mer

--- a/tests/unit/test_workflow_mermaid_rich.py
+++ b/tests/unit/test_workflow_mermaid_rich.py
@@ -60,3 +60,28 @@ def test_mermaid_empty_project_is_safe(tmp_path):
     mer = _build_workflow_mermaid(tmp_path)
     assert mer.startswith("graph TD")
     assert "No analysis steps yet" in mer
+
+
+def test_hybrid_software_component_in_dag(tmp_path):
+    """3.2.2 hybrid: an inner software component (build manifest / .git)
+    appears in the DAG with an 'informs' edge from the latest step."""
+    from research_os.project_ops import detect_software_components
+
+    scaffold_minimal_workspace(tmp_path, "Hybrid", ide_flags=[], copy_agents=False)
+    (tmp_path / "KBUtilLib").mkdir()
+    (tmp_path / "KBUtilLib" / "pyproject.toml").write_text("[project]\nname='k'\n")
+    s1 = create_numbered_experiment(
+        tmp_path, "method spec", enforce_predecessor_finalized=False
+    )["path_id"]
+    _fill(tmp_path / "workspace" / s1, "Spec the clustering method")
+
+    comps = detect_software_components(tmp_path)
+    assert any(c["name"] == "KBUtilLib" and c["kind"] == "python" for c in comps)
+    # RO scaffold dirs are never flagged as software.
+    names = {c["name"] for c in comps}
+    assert "workspace" not in names and "inputs" not in names and "docs" not in names
+
+    mer = _build_workflow_mermaid(tmp_path)
+    assert 'subgraph software_component["Software"]' in mer
+    assert "KBUtilLib" in mer
+    assert f"{s1.replace('-', '_')} -. informs .-> sw_KBUtilLib" in mer


### PR DESCRIPTION
Bumps version to **v3.2.2**. See CHANGELOG.md for the full entry.

Driven by an end-to-end audit of a real research+software project (`reaction-similarity`). Twelve fixes across ten gated waves; backwards-compatible (every tool keeps its name + schema).

## Highlights
- **Step gate now inspects `plan.md`** — blocks scaffolding step N+1 when the prior step's plan is the unfilled seed (the exact slip found on disk).
- **Import-driven `requirements.txt`** — pins only the project's own imports; excludes the research-os server stack that shares the interpreter.
- **`inputs/` soft-guard** — only `.os_state/` hard-locked; raw_data/literature need `force=true`+OK; `inputs/context/` is a free drop-zone.
- **Realistic workflow DAG** — real data-dependency edges, purposes, statuses, dead-ends, branches, software node; replaces the `init → every step` fan-out.
- **researcher_config = AI operating contract** — `sys_boot.config_directives` + reconcile hint; AI fills/updates autonomy/output_types/citation_style/compute-env; new `agent_notes`.
- **Live context drop-zone detection** — `sys_boot`/`tool_route` surface new files dropped in `context/`.
- **Hybrid mode** — `workspace.mode: hybrid`; detect inner software components; DAG `Software` node.
- **MCP consistency + restart notice + `--mcp-scope global|workspace`**; canonical root `.mcp.json` for Claude Code.
- **Declutter** — no `codemeta.json` at scaffold; per-step `outputs/reports/` created on demand; glossary nudge.

## Gate
preflight **32/32** · **1906 passed, 13 skipped** · ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)