### PR TITLE
v3.4.0 — research-os route (terminal-facing router preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.4.0] — terminal-facing router preview (2026-06-22)
+
+A MINOR release that lets you drive the protocol router straight from the
+terminal, no IDE or MCP client required. Fully backwards-compatible.
+
+### Added
+- `research-os route "<prompt>"` — runs the same hierarchical router the
+  MCP `tool_route` uses and prints the routing decision: matched
+  protocol, intent class / sub-intent, resolved level, complexity, tier,
+  planned tool sequence, and ranked alternatives. `--json` emits the raw
+  decision for scripting or non-MCP agents. Read-only: never persists an
+  active plan. Reads project workflow shape + workspace mode when run
+  inside a workspace; works statelessly anywhere else.
+
+### Improved
+- Shell completion now offers the `hermes` and `route` subcommands.
+- CLI reference documents `research-os route`.
+
+---
+
 ## [3.3.0] — self-improving, adaptive Research-OS (2026-06-22)
 
 A MINOR release that makes Research-OS adapt to the work in front of it and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.3.0
+version: 3.4.0
 date-released: 2026-06-22
 keywords:
   - research-data-management

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -129,6 +129,27 @@ up the new server and skill.
 
 ---
 
+## `research-os route "<prompt>"`
+
+Preview the protocol router from the terminal — the same hierarchical
+router the MCP `tool_route` calls. Prints the matched protocol, intent
+class, planned tool sequence, and ranked alternatives so you can see
+what Research-OS *would* do for a request without opening an IDE. It is
+read-only: it never persists an active plan.
+
+```bash
+# Human-readable decision.
+research-os route "fit a mixed-effects model to my data"
+
+# Raw decision as JSON (for scripting / non-MCP agents).
+research-os route "draft the methods section" --json
+```
+
+Run it inside a workspace for state-aware routing (it reads the project
+workflow shape + workspace mode), or anywhere for a stateless preview.
+
+---
+
 ## `research-os api-key add | list | rotate | remove | test`
 
 Manages the `api_keys:` block of `inputs/researcher_config.yaml`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.3.0"
+version = "3.4.0"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.3.0"
+__version__ = "3.4.0"

--- a/src/research_os/cli.py
+++ b/src/research_os/cli.py
@@ -830,6 +830,101 @@ def cmd_hermes(args: argparse.Namespace) -> int:
 
 
 # ---------------------------------------------------------------------------
+# route subcommand — preview the protocol router from the terminal
+# ---------------------------------------------------------------------------
+
+
+def cmd_route(args: argparse.Namespace) -> int:
+    """Run the runtime protocol router on a prompt and print the decision.
+
+    This is the same ``route_request`` the MCP ``tool_route`` calls, exposed
+    so a researcher (or a non-MCP agent) can preview what Research-OS would
+    do for a given request without loading an IDE. Read-only: never persists
+    an active plan.
+    """
+    import json as _json
+
+    from research_os import wizard
+    from research_os.tools.actions.router import route_request
+
+    if getattr(args, "no_color", False):
+        wizard.disable_color()
+
+    prompt = (args.prompt or "").strip()
+    if not prompt:
+        wizard.fail("Empty prompt", 'Usage: research-os route "<your request>"')
+        return 2
+
+    root = _find_workspace_root() or Path.cwd()
+
+    result = route_request(prompt, root, persist_plan=False)
+
+    if getattr(args, "json", False):
+        print(_json.dumps(result, indent=2, default=str))
+        return 0 if result.get("status") == "success" else 1
+
+    if result.get("status") != "success":
+        wizard.fail("Routing failed", result.get("message", "unknown error"))
+        return 1
+
+    C = wizard._C
+    level = result.get("resolved_level")
+    intent = result.get("intent_class") or "—"
+    sub = result.get("sub_intent") or "—"
+    primary = result.get("primary_protocol")
+    shortcut = result.get("shortcut_tool")
+    complexity = result.get("complexity") or "—"
+    tier = result.get("tier")
+    why = result.get("why_matched") or result.get("why") or ""
+    ask = result.get("ask_user")
+    decomposition = result.get("decomposition") or []
+    alternatives = result.get("alternatives") or []
+    triggers = result.get("matched_triggers") or []
+
+    print()
+    print(f"  {C.BOLD}Route for:{C.RESET} {prompt}")
+    print(f"  {C.GREY}{wizard._hr()}{C.RESET}")
+    print(f"  {C.BOLD}intent{C.RESET}        {intent} / {sub}")
+    if primary:
+        print(f"  {C.BOLD}protocol{C.RESET}      {C.GREEN}{primary}{C.RESET}")
+    if shortcut:
+        print(f"  {C.BOLD}shortcut{C.RESET}      {C.GREEN}{shortcut}{C.RESET}")
+    print(f"  {C.BOLD}level{C.RESET}         L{level}   "
+          f"complexity={complexity}" + (f"   tier={tier}" if tier else ""))
+    if triggers:
+        print(f"  {C.BOLD}triggers{C.RESET}      {', '.join(str(t) for t in triggers)}")
+    if why:
+        print(f"  {C.BOLD}why{C.RESET}           {C.GREY}{why}{C.RESET}")
+    if ask:
+        print(f"  {C.BOLD}{C.YELLOW}ask first{C.RESET}     {ask}")
+
+    if decomposition:
+        print()
+        print(f"  {C.BOLD}planned tool sequence{C.RESET}")
+        for i, step in enumerate(decomposition, 1):
+            tool = step.get("tool") if isinstance(step, dict) else str(step)
+            note = step.get("why", "") if isinstance(step, dict) else ""
+            line = f"    {i:>2}. {tool}"
+            if note:
+                line += f"   {C.GREY}{note}{C.RESET}"
+            print(line)
+
+    if alternatives:
+        print()
+        print(f"  {C.BOLD}alternatives{C.RESET}")
+        for alt in alternatives[:4]:
+            if isinstance(alt, dict):
+                aid = alt.get("name") or alt.get("protocol") or alt.get("primary_protocol") or "—"
+                ascore = alt.get("score")
+            else:
+                aid, ascore = str(alt), None
+            sc = f"  ({ascore})" if ascore is not None else ""
+            print(f"    - {aid}{C.GREY}{sc}{C.RESET}")
+    print()
+    return 0
+
+
+# ---------------------------------------------------------------------------
 # api-key subcommand — manage api_keys in inputs/researcher_config.yaml
 # ---------------------------------------------------------------------------
 
@@ -1186,8 +1281,8 @@ def cmd_refresh(args: argparse.Namespace) -> int:
 # the fish completion script and the argparse subparser registry stay in
 # sync (the test suite cross-checks these).
 SUBCOMMANDS_FOR_COMPLETION = (
-    "init", "ide", "mcp", "api-key", "start", "doctor", "refresh",
-    "completion",
+    "init", "ide", "mcp", "hermes", "route", "api-key", "start", "doctor",
+    "refresh", "completion",
 )
 
 
@@ -1571,6 +1666,28 @@ def build_parser() -> argparse.ArgumentParser:
     p_hermes.add_argument("--no-color", action="store_true",
                           help="Disable ANSI styling.")
 
+    # ── route ───────────────────────────────────────────────────────────
+    p_route = sub.add_parser(
+        "route",
+        help="Preview the protocol router for a prompt (no IDE needed).",
+        description=(
+            "Run the same hierarchical router the MCP `tool_route` uses and\n"
+            "print the routing decision: matched protocol, intent class,\n"
+            "planned tool sequence, and alternatives. Read-only — never\n"
+            "persists an active plan. Run inside a workspace for state-aware\n"
+            "routing, or anywhere for a stateless preview.\n\n"
+            "Examples:\n"
+            '  research-os route "fit a mixed-effects model to my data"\n'
+            '  research-os route "draft the methods section" --json'
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p_route.add_argument("prompt", help="The request to route.")
+    p_route.add_argument("--json", action="store_true",
+                         help="Emit the raw routing decision as JSON.")
+    p_route.add_argument("--no-color", action="store_true",
+                         help="Disable ANSI styling.")
+
     # ── api-key ─────────────────────────────────────────────────────────
     p_api = sub.add_parser(
         "api-key",
@@ -1755,6 +1872,8 @@ def main() -> None:
         sys.exit(cmd_mcp(args))
     elif args.command == "hermes":
         sys.exit(cmd_hermes(args))
+    elif args.command == "route":
+        sys.exit(cmd_route(args))
     elif args.command == "api-key":
         sys.exit(cmd_api_key(args))
     elif args.command == "start":

--- a/tests/unit/test_route_cli.py
+++ b/tests/unit/test_route_cli.py
@@ -1,0 +1,78 @@
+"""Tests for `research-os route` — terminal-facing protocol router preview.
+
+Exercises the CLI wrapper around ``route_request``: human-readable output,
+``--json`` mode, the empty-prompt guard, and that it never persists an
+active plan (read-only preview).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from research_os import cli
+from research_os.tools.actions.router import route_request
+
+
+def test_route_request_engine_returns_decision(tmp_path):
+    """The underlying engine resolves a clear prompt to a protocol."""
+    res = route_request("draft the methods section", tmp_path, persist_plan=False)
+    assert res["status"] == "success"
+    assert res.get("primary_protocol")
+    assert res.get("resolved_level") in (0, 2, 3)
+
+
+def test_route_cli_human_output(capsys, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rc = _run_route("fit a mixed effects model to my data", no_color=True)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Route for:" in out
+    assert "intent" in out
+    # A protocol or shortcut line should appear.
+    assert ("protocol" in out) or ("shortcut" in out)
+
+
+def test_route_cli_json_output(capsys, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rc = _run_route("draft the methods section", json_out=True, no_color=True)
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["status"] == "success"
+    assert "primary_protocol" in payload
+    assert "decomposition" in payload
+
+
+def test_route_cli_empty_prompt_guard(capsys, tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rc = _run_route("   ", no_color=True)
+    assert rc == 2
+
+
+def test_route_cli_is_read_only(capsys, tmp_path, monkeypatch):
+    """Preview must not write an active plan, even for a complex prompt."""
+    monkeypatch.chdir(tmp_path)
+    _run_route(
+        "design and run a full multi-factor experiment with analysis and writeup",
+        no_color=True,
+    )
+    # No active plan persisted anywhere under the cwd.
+    assert not list(tmp_path.rglob("active_plan.json"))
+
+
+def test_route_in_subcommands_for_completion():
+    assert "route" in cli.SUBCOMMANDS_FOR_COMPLETION
+    assert "hermes" in cli.SUBCOMMANDS_FOR_COMPLETION
+
+
+def _run_route(prompt: str, *, json_out: bool = False, no_color: bool = False) -> int:
+    """Invoke cmd_route with a hand-built args namespace."""
+    import argparse
+
+    args = argparse.Namespace(
+        command="route",
+        prompt=prompt,
+        json=json_out,
+        no_color=no_color,
+    )
+    return cli.cmd_route(args)


### PR DESCRIPTION
Adds `research-os route "<prompt>"`: runs the same hierarchical router as MCP tool_route and prints the routing decision (protocol, intent, planned tool sequence, alternatives); `--json` for scripting. Read-only — never persists an active plan. Shell completion gains `hermes`+`route`; CLI docs updated.

Gate: preflight 33/33 · pytest 2287 passed / 13 skipped · ruff clean.