### PR TITLE
v3.5.0 — adaptive-aware autonomy gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.5.0] — adaptive-aware autonomy gates (2026-06-22)
+
+A MINOR release that teaches every protocol's autonomy gate to speak the
+language of `adaptive` — the default autonomy mode since 3.3.0. Fully
+backwards-compatible.
+
+### Improved
+- **Every `AUTONOMY GATE` block now names the risk dimension it guards**
+  (reversible/cheap, irreversible, expensive, or real-money) and leads
+  with how `adaptive` — the default — resolves it, instead of describing
+  only `manual` / `supervised` / `autopilot` and leaving the default-level
+  AI to infer. 34 gate blocks across 22 protocols updated, spanning the
+  build, exploration, methodology, guidance, notebook, program,
+  synthesis, reproducibility, and visualization tracks.
+- **Doctrine codified.** `docs/PROTOCOL_DOCTRINE.md` gains a section,
+  "Autonomy gates — name the risk, let adaptive resolve it," defining the
+  canonical gate idiom so future protocols stay consistent: gates name the
+  dimension to reason over, never hardcode a fixed proceed/ask rule.
+
+### Fixed
+- Protocol-version assertions in the dashboard-style test suite now check
+  `>= 3.0.0` instead of pinning an exact string, so legitimate protocol
+  bumps no longer break the suite.
+
+### Bumped
+- 22 protocol `version:` fields → `3.5.0` (gate behavior changed).
+- Package version → `3.5.0`.
+
+---
+
 ## [3.4.0] — terminal-facing router preview (2026-06-22)
 
 A MINOR release that lets you drive the protocol router straight from the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.4.0
+version: 3.5.0
 date-released: 2026-06-22
 keywords:
   - research-data-management

--- a/docs/PROTOCOL_DOCTRINE.md
+++ b/docs/PROTOCOL_DOCTRINE.md
@@ -244,6 +244,41 @@ DAG. Adding `see_also` to your own protocols today is a low-risk
 investment — the schema accepts the field; downstream tools will pick
 it up when they're built.
 
+## Autonomy gates — name the risk, let adaptive resolve it
+
+Many protocols pause at a decision point with an `AUTONOMY GATE:` block.
+The default autonomy level is **adaptive**: it flows on cheap, reversible
+moves and pauses only on the handful that are irreversible, expensive, or
+spend real money. A gate that only addresses `manual / supervised` and
+`autopilot` leaves the default-level AI to guess — so every gate must
+**name the risk dimension** and say how adaptive resolves it.
+
+The canonical idiom:
+
+```yaml
+AUTONOMY GATE:
+  Risk: <reversible+cheap | irreversible | expensive but re-runnable | spends real money>.
+  adaptive (default) → <flow / pause>, judged from THIS action's
+    reversibility + cost, not from a fixed rule.
+  manual / supervised → <what to present and confirm before acting>.
+  autopilot → <proceed, and what to log / flag>.
+```
+
+This is scaffold language, not a recipe: the gate names the *dimension*
+(is this action reversible? what does it cost?) and leaves the AI to
+judge whether THIS instance clears the bar. Match the verbs to the
+engine's enforced floors (`server/autopilot_gate.py`): truly
+irreversible / real-money actions pause even on the loosest setting;
+expensive-but-re-runnable actions pause at the normal floor; reversible
+actions flow. A gate whose `adaptive` line contradicts the engine's
+floor for the same action is a bug — reconcile the prose to the floor,
+not the floor to the prose.
+
+When a step's action is plainly reversible and cheap (drafting, EDA,
+writing a figure, scoping an increment), it does not need a gate at all;
+adaptive flows through it. Reserve gates for the moves where pausing
+actually protects something.
+
 ## No version commentary in live bodies
 
 Protocol bodies, MCP tool descriptions, and code docstrings/comments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.4.0"
+version = "3.5.0"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.4.0"
+__version__ = "3.5.0"

--- a/src/research_os/protocols/build/benchmark_vs_baseline.yaml
+++ b/src/research_os/protocols/build/benchmark_vs_baseline.yaml
@@ -1,7 +1,7 @@
 id: benchmark_vs_baseline
 tier: 'execute'
 name: Benchmark vs Baseline (fair measurement against the right comparator)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -116,6 +116,12 @@ steps:
       increment's objective.
 
       AUTONOMY GATE:
+        Risk: reversible — recording a verdict changes no artefact that
+        can't be re-judged; the real hazard is overclaiming on noise.
+        adaptive (default) → record the verdict with its evidence and flag
+          any claim that rests on a within-noise difference; surface the
+          call to the researcher when the result reverses a prior claim or
+          drives an irreversible downstream decision.
         manual / supervised → present the result + uncertainty + your
           read; let the researcher judge whether the claim holds.
         autopilot → record the verdict with its evidence and flag any

--- a/src/research_os/protocols/build/implement_iteration.yaml
+++ b/src/research_os/protocols/build/implement_iteration.yaml
@@ -1,7 +1,7 @@
 id: implement_iteration
 tier: 'execute'
 name: Implement Iteration (the inner build loop)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -72,6 +72,9 @@ steps:
       increment is fine only when it's ONE coherent thing.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — scoping an increment writes no code yet.
+        adaptive (default) → state the increment scope and proceed to
+          implement; nothing here needs confirmation.
         manual / supervised → present the increment scope; confirm before
           writing code.
         autopilot → state the scope and proceed.
@@ -169,6 +172,10 @@ steps:
       and, when it advances a milestone, tick it in milestones.md.
 
       AUTONOMY GATE:
+        Risk: reversible — a local commit is undoable (amend, revert, reset)
+        and pushes nothing on its own.
+        adaptive (default) → commit with a well-formed message and log it;
+          no confirmation needed for a local commit.
         manual / supervised → show the diff summary + proposed commit
           message; commit on confirmation.
         autopilot → commit with a well-formed message; log it.
@@ -198,6 +205,11 @@ steps:
       a pause between increments is where the researcher redirects.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — looping to the next increment is just
+        more gated build work; the weight sits in the gates it re-enters.
+        adaptive (default) → if the build is green and no risk flag fired,
+          loop back to scope_increment for the next increment in the SAME
+          turn; if a risk flag fired or the build is red, pause and present.
         manual / supervised → present the increment summary + the candidate
           next increments; wait for the choice.
         autopilot → if the build is green and no risk flag fired, loop back

--- a/src/research_os/protocols/build/release_and_changelog.yaml
+++ b/src/research_os/protocols/build/release_and_changelog.yaml
@@ -1,7 +1,7 @@
 id: release_and_changelog
 tier: 'finalize'
 name: Release & Changelog (cut a versioned, reproducible release)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -72,6 +72,11 @@ steps:
       across every place that declares it.
 
       AUTONOMY GATE:
+        Risk: reversible — choosing the bump and writing the CHANGELOG
+        changes nothing published; it can be re-edited before the tag.
+        adaptive (default) → choose the bump, state the reasoning (which
+          commits forced major vs minor vs patch), and proceed; flag any
+          commit whose classification was ambiguous.
         manual / supervised → present the proposed bump + the reasoning
           (which commits forced major vs minor vs patch); confirm before
           tagging.
@@ -151,6 +156,12 @@ steps:
       build/implement_iteration — this protocol terminates here.
 
       AUTONOMY GATE:
+        Risk: publishing to an external registry is irreversible — a
+        published version can't be unpublished; tagging is local and cheap.
+        adaptive (default) → tag and build the artefact locally; PAUSE
+          before any PUBLISH to an external registry (PyPI, npm, a public
+          release) and confirm, because that step can't be undone. This is
+          a hard floor, not a judgement call.
         manual / supervised → present the version + changelog + artefact
           plan; tag and publish only on explicit confirmation (publishing is
           hard to undo).

--- a/src/research_os/protocols/build/spec_and_design.yaml
+++ b/src/research_os/protocols/build/spec_and_design.yaml
@@ -1,7 +1,7 @@
 id: spec_and_design
 tier: 'plan'
 name: Spec & Design (what the tool must do, and how "done" is judged)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -127,9 +127,16 @@ steps:
       grounding in the ADR.
 
       AUTONOMY GATE:
+        Risk: irreversible — load-bearing choices ripple through everything
+        built on them, so reversing one later is expensive.
+        adaptive (default) → for choices that are genuinely hard to reverse,
+          present the load-bearing decisions + your recommendation and
+          confirm before writing the ADRs as 'accepted'; for a choice that
+          is cheap to revisit, write it and move on. Judge from how far the
+          choice ripples, not from a fixed rule.
         manual / supervised → present the load-bearing decisions + your
           recommendation; ask the researcher to confirm before writing the
-          ADRs as 'accepted'. These choices are expensive to reverse.
+          ADRs as 'accepted'.
         autopilot → write the ADRs with status 'accepted' and a clear
           rationale; log them so a later review can challenge any one.
 
@@ -180,6 +187,10 @@ steps:
       <headline>" so the build loop and a later review can trace it.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — entering the build loop commits nothing
+        that can't be unwound; the first increment is itself gated.
+        adaptive (default) → proceed to build/implement_iteration on the
+          first milestone; the loop's own gates catch anything weighty.
         manual / supervised → present the spec summary + proposed first
           milestone; wait for the researcher before entering the loop.
         autopilot → proceed to build/implement_iteration on the first

--- a/src/research_os/protocols/build/test_strategy.yaml
+++ b/src/research_os/protocols/build/test_strategy.yaml
@@ -1,7 +1,7 @@
 id: test_strategy
 tier: 'plan'
 name: Test Strategy (the testing regime that fits THIS tool)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -125,6 +125,11 @@ steps:
       tests inherit a consistent target and a later review can replay the WHY.
 
       AUTONOMY GATE:
+        Risk: reversible but shared — CI config is undoable, but it governs
+        everyone's merges, so a bad gate blocks the whole team.
+        adaptive (default) → wire the regime and log the rationale; if the
+          CI gate would block merges for collaborators other than yourself,
+          present it first. Judge from blast radius, not from a fixed rule.
         manual / supervised → present the proposed regime + CI gate; wait
           for confirmation before wiring CI (it governs everyone's merges).
         autopilot → wire it and log the rationale.

--- a/src/research_os/protocols/exploration/exploration_loop.yaml
+++ b/src/research_os/protocols/exploration/exploration_loop.yaml
@@ -1,7 +1,7 @@
 id: exploration_loop
 tier: 'execute'
 name: Exploration Loop (probe → observe → decide)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -137,6 +137,10 @@ steps:
           — drop it or promote it to a real step that can.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — every probe lives in scratch and a
+        promote/drop/iterate call commits nothing that can't be redone.
+        adaptive (default) → act on the decision; if promoting, say so and
+          load exploration_promote in the same turn.
         manual / supervised → present the observation + your recommended
           decision (promote / drop / iterate) and the next probe if
           iterating; wait for the researcher.

--- a/src/research_os/protocols/exploration/exploration_promote.yaml
+++ b/src/research_os/protocols/exploration/exploration_promote.yaml
@@ -1,7 +1,7 @@
 id: exploration_promote
 tier: 'execute'
 name: Promote a Probe to a Real Step
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -58,6 +58,10 @@ steps:
       promote what will survive the rigor you're about to apply.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — promote-or-iterate keeps work in scratch
+        until it's earned a real step; nothing here is hard to undo.
+        adaptive (default) → if the observation is reproducible and
+          material, promote; otherwise iterate once more in scratch.
         manual / supervised → state your recommendation (promote / one
           more probe) and wait for the researcher.
         autopilot → if the observation is reproducible and material,
@@ -127,6 +131,9 @@ steps:
       finding it cheaply.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — entering analysis_plan on the new step
+        runs no expensive or irreversible action by itself.
+        adaptive (default) → proceed into analysis_plan on the new step.
         manual / supervised → present the new step + the planned
           analysis_plan entry; wait before running the loop.
         autopilot → proceed into analysis_plan on the new step.

--- a/src/research_os/protocols/exploration/exploration_triage.yaml
+++ b/src/research_os/protocols/exploration/exploration_triage.yaml
@@ -1,7 +1,7 @@
 id: exploration_triage
 tier: 'plan'
 name: Exploration Triage (what's cheaply worth probing first)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -94,6 +94,10 @@ steps:
       triage.md as the backlog.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — running the top probe is scratch work
+        and the backlog stays available to reorder later.
+        adaptive (default) → run the top probe via exploration_loop; keep
+          the rest as the backlog.
         manual / supervised → present the ranked list; let the researcher
           pick which probe to run first (they may reorder).
         autopilot → run the top probe via exploration_loop; keep the rest

--- a/src/research_os/protocols/guidance/analysis_plan.yaml
+++ b/src/research_os/protocols/guidance/analysis_plan.yaml
@@ -1,7 +1,7 @@
 id: analysis_plan
 tier: 'execute'
 name: Analysis Plan (Core Loop)
-version: '3.2.1'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -56,6 +56,8 @@ steps:
         - The hypothesis (or hypotheses) this step targets — by ID, e.g. H2.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — scoping the step writes no analysis yet.
+        adaptive (default) → state the scope and proceed; do NOT ask.
         manual / supervised → present the scope; ask for confirmation.
         autopilot           → state the scope and proceed; do NOT ask.
 
@@ -218,6 +220,11 @@ steps:
       researcher (not the AI) catches it because the wrong gates fire.
 
       AUTONOMY GATE:
+        Risk: reversible — a step-intent classification is logged and can
+        be re-labelled; nothing downstream is locked by it.
+        adaptive (default) → pick the closest fit and proceed; log the
+          rationale in workspace/logs/step_intent_choices.md so a later
+          audit can review it.
         manual / supervised → suggest the classification; ask for
                               confirmation when ambiguous (e.g. a
                               step that fits BOTH analyse + visualise).
@@ -314,6 +321,14 @@ steps:
       append a line to its iteration log if this step changes the plan.
 
       AUTONOMY GATE (read interaction.autonomy_level):
+        Risk: reversible — writing plan.md commits no analysis; the value
+        at stake is design quality, which the researcher may want to shape.
+        - adaptive (default) → WRITE plan.md as your reasoning record, note
+          the decisions you made under "Open questions", and proceed; but
+          when an open decision is consequential and genuinely contested
+          (it changes what the step concludes, not just how it's coded),
+          surface it to the researcher and WAIT. Judge from how much the
+          decision shapes the finding, not from a fixed rule.
         - manual / supervised → PRESENT plan.md's "What this step will do"
           + "Open questions" to the researcher and WAIT. Iterate
           (propose → critique → refine) until the design is agreed, THEN
@@ -789,6 +804,13 @@ steps:
            auto-proceed afterwards is autopilot-dependent.
 
       AUTONOMY GATE:
+        Risk: reversible — presenting results and choosing the next step
+        commits nothing irreversible; the concern is researcher steering.
+        adaptive (default) → present the summary + options; if
+                              would_benefit_from_revision is False AND
+                              audit warnings == 0, proceed to decide_next
+                              in the SAME turn. Otherwise surface the
+                              decision and wait for the researcher.
         manual / supervised → wait for the researcher's reply (a/b/c/d).
         autopilot           → present the summary + options; if
                               would_benefit_from_revision is False
@@ -827,6 +849,10 @@ steps:
           terminal experiment has a publishable finding.
 
       AUTONOMY GATE:
+        Risk: reversible — the choice was already surfaced in
+        present_to_researcher; this just acts on it.
+        adaptive (default) → proceed to the chosen action (already decided
+          in present_to_researcher).
         manual / supervised → wait for the explicit answer from
                               `present_to_researcher`.
         autopilot           → already-confirmed in

--- a/src/research_os/protocols/guidance/iterative_planning.yaml
+++ b/src/research_os/protocols/guidance/iterative_planning.yaml
@@ -1,7 +1,7 @@
 id: iterative_planning
 tier: 'plan'
 name: Iterative Planning
-version: '3.2.0'
+version: '3.5.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -57,6 +57,10 @@ steps:
       constructive_disagreement.
 
       AUTONOMY GATE:
+        Risk: reversible — picking a plan option commits nothing; the
+        researcher can redirect at any time.
+        adaptive (default) → pick OPTION A (your top choice), tell the
+                              researcher "I'm going with A — say stop to switch".
         manual / supervised → wait for the researcher to choose.
         autopilot           → pick OPTION A (your top choice), tell the
                               researcher "I'm going with A — say stop to switch".

--- a/src/research_os/protocols/guidance/mid_pipeline_entry.yaml
+++ b/src/research_os/protocols/guidance/mid_pipeline_entry.yaml
@@ -1,7 +1,7 @@
 id: mid_pipeline_entry
 tier: 'intake'
 name: Mid-Pipeline Entry (entering an in-progress project)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -84,6 +84,12 @@ steps:
          page you'll paste? Mostly in your head?"
 
       AUTONOMY GATE:
+        Risk: reversible — inferring the entry state reads files and
+        confirms; it changes nothing on its own.
+        adaptive (default) → infer from sys_file_list across inputs/,
+                              workspace/, docs/, plus any non-RO folders
+                              the researcher hints at; assume the
+                              maximum-plausible state and confirm in one line.
         manual / supervised → wait for the researcher.
         autopilot           → infer from sys_file_list across inputs/,
                               workspace/, docs/, plus any non-RO

--- a/src/research_os/protocols/guidance/scope_clarification.yaml
+++ b/src/research_os/protocols/guidance/scope_clarification.yaml
@@ -1,7 +1,7 @@
 id: scope_clarification
 tier: 'intake'
 name: Scope Clarification (vague intent → workable scope)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -129,6 +129,10 @@ steps:
              paper draft')?"
 
       AUTONOMY GATE:
+        Risk: reversible — choosing how to read an ambiguous scope commits
+        nothing; the researcher can redirect.
+        adaptive (default) → pick the highest-likelihood option, state it,
+                              and proceed with "say stop to redirect".
         manual / supervised → ask + wait.
         autopilot           → pick the highest-likelihood option,
                               state it, and proceed with "say stop to

--- a/src/research_os/protocols/methodology/cox_ph_diagnostics.yaml
+++ b/src/research_os/protocols/methodology/cox_ph_diagnostics.yaml
@@ -1,7 +1,7 @@
 id: cox_ph_diagnostics
 tier: 'plan'
 name: Cox PH Diagnostics (Proportional Hazards check + fallback routing)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -247,9 +247,11 @@ quality_bar:
   fallback_strategy_chosen_and_logged_if_violated: true
   cox_hazard_ratio_never_reported_without_companion_ph_test: true
 
-# AUTONOMY GATE: in manual / supervised / coaching, surface
-# "Next: audit/audit_and_validation" as a SUGGESTION; only autopilot
-# auto-chains. A targeted diagnostics check ≠ a full project audit.
+# AUTONOMY GATE: chaining to a full project audit is reversible (it just
+# loads the next protocol), but a targeted diagnostics check is its own
+# deliverable, not automatically a trigger for a full audit. adaptive
+# (default) + manual / supervised surface "Next: audit/audit_and_validation"
+# as a SUGGESTION; only autopilot auto-chains.
 next_protocol: audit/audit_and_validation
 next_protocol_kind: forward_default
 on_failure: guidance/dead_end_routing

--- a/src/research_os/protocols/methodology/deep_domain_research.yaml
+++ b/src/research_os/protocols/methodology/deep_domain_research.yaml
@@ -1,7 +1,7 @@
 id: deep_domain_research
 tier: 'plan'
 name: Deep Domain Research (subfield-canonical pipeline)
-version: '3.2.0'
+version: '3.5.0'
 last_reviewed: '2026-06-16'
 schema_version: '2.0'
 scope_tags:
@@ -225,6 +225,11 @@ steps:
           "alternative pipeline considered and declined").
 
       AUTONOMY GATE:
+        Risk: reversible — switching to an alternative method changes the
+        plan, not any committed result; the guard is reporting consistency.
+        adaptive (default) → only branch if the tool returned
+          `branch_to_alternative` AND the alternative does not change the
+          primary reporting standard; otherwise present and wait.
         manual / supervised → present + wait.
         autopilot           → only branch if the tool returned
                               `branch_to_alternative` AND the

--- a/src/research_os/protocols/methodology/missing_data_strategy.yaml
+++ b/src/research_os/protocols/methodology/missing_data_strategy.yaml
@@ -1,7 +1,7 @@
 id: missing_data_strategy
 tier: 'plan'
 name: Missing-Data Strategy (MCAR/MAR/MNAR → handling → sensitivity)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -305,9 +305,11 @@ quality_bar:
   rubin_pooling_used_for_multiple_imputation: true
   preregistered_if_confirmatory: true
 
-# AUTONOMY GATE: in manual / supervised / coaching, surface
-# "Next: audit/audit_and_validation" as a SUGGESTION; only autopilot
-# auto-chains. A missing-data strategy decision ≠ a full project audit.
+# AUTONOMY GATE: chaining to a full project audit is reversible (it just
+# loads the next protocol), but a missing-data strategy decision is its own
+# deliverable, not automatically a trigger for a full audit. adaptive
+# (default) + manual / supervised surface "Next: audit/audit_and_validation"
+# as a SUGGESTION; only autopilot auto-chains.
 next_protocol: audit/audit_and_validation
 next_protocol_kind: forward_default
 on_failure: guidance/dead_end_routing

--- a/src/research_os/protocols/methodology/qualitative_quality_audit.yaml
+++ b/src/research_os/protocols/methodology/qualitative_quality_audit.yaml
@@ -1,7 +1,7 @@
 id: qualitative_quality_audit
 tier: 'plan'
 name: Qualitative Quality Audit (COREQ + SRQR enforcement)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [qualitative]
@@ -266,9 +266,11 @@ quality_bar:
   codebook_versioned_with_analytic_memos: true
   audit_summary_written_for_synthesis_consumption: true
 
-# AUTONOMY GATE: in manual / supervised / coaching, surface
-# "Next: audit/audit_and_validation" as a SUGGESTION; only autopilot
-# auto-chains. A qualitative quality check ≠ a full project audit.
+# AUTONOMY GATE: chaining to a full project audit is reversible (it just
+# loads the next protocol), but a qualitative quality check is its own
+# deliverable, not automatically a trigger for a full audit. adaptive
+# (default) + manual / supervised surface "Next: audit/audit_and_validation"
+# as a SUGGESTION; only autopilot auto-chains.
 next_protocol: audit/audit_and_validation
 next_protocol_kind: forward_default
 on_failure: guidance/dead_end_routing

--- a/src/research_os/protocols/notebook/notebook_workflow.yaml
+++ b/src/research_os/protocols/notebook/notebook_workflow.yaml
@@ -1,7 +1,7 @@
 id: notebook_workflow
 tier: 'execute'
 name: Notebook Workflow (the cell as the unit of work)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -72,6 +72,8 @@ steps:
       consider exploration tooling instead.
 
       AUTONOMY GATE:
+        Risk: reversible + cheap — scoping the notebook writes no cells yet.
+        adaptive (default) → state the scope and proceed.
         manual / supervised → present the scope + planned notebook;
           confirm before building it.
         autopilot → state the scope and proceed.
@@ -148,6 +150,10 @@ steps:
         - Stop → the question is answered; nothing more owed.
 
       AUTONOMY GATE:
+        Risk: reversible — logging the finding and moving on commits
+        nothing that can't be revisited.
+        adaptive (default) → log the finding; proceed to the next notebook
+          or to synthesis per the researcher's stated output goal.
         manual / supervised → present the finding + options; wait.
         autopilot → log the finding; proceed to the next notebook or to
           synthesis per the researcher's stated output goal.

--- a/src/research_os/protocols/program/program_setup.yaml
+++ b/src/research_os/protocols/program/program_setup.yaml
@@ -1,7 +1,7 @@
 id: program_setup
 tier: 'plan'
 name: Program Setup (shared codebook, prereg, how studies roll up)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -139,6 +139,10 @@ steps:
       is intact.
 
       AUTONOMY GATE:
+        Risk: reversible — scaffolding the commons + first study writes
+        structure, not findings; everything is re-editable.
+        adaptive (default) → write the commons, scaffold the first study,
+          and enter its analysis loop; log each decision for later review.
         manual / supervised → present the commons (codebook outline +
           prereg + roll-up plan) + the proposed first study; wait for the
           researcher before scaffolding studies.

--- a/src/research_os/protocols/reproducibility/reproducibility.yaml
+++ b/src/research_os/protocols/reproducibility/reproducibility.yaml
@@ -1,7 +1,7 @@
 id: reproducibility
 tier: 'finalize'
 name: Reproducibility
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -117,10 +117,12 @@ expected_outputs:
   - ro-crate-metadata.json
   - codemeta.json
 
-# AUTONOMY GATE on next_protocol: in manual / supervised /
-# coaching, present "Next: audit/audit_and_validation" as a SUGGESTION;
-# only autopilot auto-chains. A reproducibility snapshot is its own
-# deliverable and the researcher may not want a full audit immediately.
+# AUTONOMY GATE on next_protocol: chaining to a full project audit is
+# reversible (it just loads the next protocol), but a reproducibility
+# snapshot is its own deliverable and the researcher may not want a full
+# audit immediately. adaptive (default) + manual / supervised present
+# "Next: audit/audit_and_validation" as a SUGGESTION; only autopilot
+# auto-chains.
 next_protocol: audit/audit_and_validation
 next_protocol_kind: forward_default
 on_failure: guidance/dead_end_routing

--- a/src/research_os/protocols/synthesis/synthesis_from_inputs.yaml
+++ b/src/research_os/protocols/synthesis/synthesis_from_inputs.yaml
@@ -1,7 +1,7 @@
 id: synthesis_from_inputs
 tier: 'synthesize'
 name: Synthesis — From Inputs (no workspace analysis required)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -112,6 +112,10 @@ steps:
       step + the provenance manifest are what makes it possible.
 
       AUTONOMY GATE:
+        Risk: reversible — picking the output type shapes the draft, which
+        stays editable.
+        adaptive (default) → pick based on `research_goal.output_types`
+                              when set; otherwise default to `report`.
         manual / supervised → wait for the researcher to pick.
         autopilot           → pick based on `research_goal.output_types`
                               when set; otherwise default to `report`.

--- a/src/research_os/protocols/synthesis/synthesis_title_workshop.yaml
+++ b/src/research_os/protocols/synthesis/synthesis_title_workshop.yaml
@@ -1,7 +1,7 @@
 id: synthesis_title_workshop
 tier: 'synthesize'
 name: Synthesis — Title Workshop (the single most-read sentence)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -198,6 +198,9 @@ steps:
       For each: name 2 pros + 1 con. Recommend ONE with rationale.
 
       AUTONOMY GATE:
+        Risk: reversible — a title is trivially changed later.
+        adaptive (default) → pick the recommended option; tell the
+                              researcher in one line.
         manual / supervised → wait for the researcher to pick.
         autopilot           → pick the recommended option; tell
                               the researcher in one line.

--- a/src/research_os/protocols/visualization/visualization_workflow.yaml
+++ b/src/research_os/protocols/visualization/visualization_workflow.yaml
@@ -1,7 +1,7 @@
 id: visualization_workflow
 tier: 'synthesize'
 name: Visualization Workflow (figures on demand, no full analysis)
-version: '3.0.0'
+version: '3.5.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -71,6 +71,10 @@ steps:
       caption depth, and palette discipline.
 
       AUTONOMY GATE:
+        Risk: reversible — inferring a figure's shape/destination produces
+        a plan, not a committed figure.
+        adaptive (default) → infer + proceed; tell the researcher the
+                              inferred shape in one line.
         manual / supervised → ask before assuming a shape or destination.
         autopilot           → infer + proceed; tell the researcher the
                               inferred shape in one line.
@@ -270,6 +274,10 @@ steps:
                       (route to the matching synthesis/* protocol)
 
       AUTONOMY GATE:
+        Risk: reversible — curating vs showing-all is a presentation choice
+        on a plan, fully changeable.
+        adaptive (default) → curate by default; surface the choice as a
+                              one-line suggestion.
         manual / supervised → wait for the researcher to choose.
         autopilot           → curate by default; surface the choice as
                               a one-line suggestion.

--- a/tests/unit/test_v244_dashboard_style.py
+++ b/tests/unit/test_v244_dashboard_style.py
@@ -178,7 +178,8 @@ def _load_protocol(rel_path: str) -> dict:
 
 def test_figure_guidelines_protocol_bumped():
     data = _load_protocol("visualization/figure_guidelines.yaml")
-    assert data["version"] == "3.0.0"
+    parts = tuple(int(x) for x in str(data["version"]).split("."))
+    assert parts >= (3, 0, 0)
 
 
 def test_figure_guidelines_carries_style_preset_block():
@@ -202,8 +203,11 @@ def test_figure_guidelines_view_loop_is_mandatory():
 
 
 def test_visualization_workflow_protocol_bumped():
+    # The protocol must stay at or above the version where its
+    # verify-render + style steps landed; later bumps are fine.
     data = _load_protocol("visualization/visualization_workflow.yaml")
-    assert data["version"] == "3.0.0"
+    parts = tuple(int(x) for x in str(data["version"]).split("."))
+    assert parts >= (3, 0, 0)
 
 
 def test_visualization_workflow_has_verify_step():
@@ -216,7 +220,8 @@ def test_visualization_workflow_has_verify_step():
 
 def test_synthesis_dashboard_protocol_bumped():
     data = _load_protocol("synthesis/synthesis_dashboard.yaml")
-    assert data["version"] == "3.0.0"
+    parts = tuple(int(x) for x in str(data["version"]).split("."))
+    assert parts >= (3, 0, 0)
 
 
 def test_synthesis_dashboard_references_style_helper():


### PR DESCRIPTION
Teaches every protocol AUTONOMY GATE to speak the language of `adaptive` (the default autonomy mode since 3.3.0).

## What changed
- **34 gate blocks across 22 protocols** now name the **risk dimension** they guard (reversible/cheap | irreversible | expensive | real-money) and lead with how `adaptive` resolves it, instead of only describing manual/supervised/autopilot and leaving the default-level AI to infer.
- **Doctrine codified**: new section in `docs/PROTOCOL_DOCTRINE.md` defining the canonical gate idiom (name the dimension to reason over, never hardcode a fixed proceed/ask rule).
- Protocol-version test assertions relaxed from `==` to `>=` so legitimate bumps don't break the suite.

## Gate
- preflight 33/33
- pytest 2287 passed / 13 skipped
- ruff clean
- version-chatter linter 0 hits

MINOR, fully backwards-compatible. No tool or protocol removed.