### PR TITLE
v3.7.0 — first-class workspace modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,53 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.7.0] — first-class workspace modes (2026-06-22)
+
+A MINOR release that makes the workspace **mode** axis coherent and
+discoverable. Research OS already supported six modes (`analysis`,
+`hybrid`, `tool_build`, `exploration`, `notebook`, `multi_study`), but
+routing only biased toward two of them and the mode system was scattered
+across the router as hardcoded `if/elif` branches with no single source
+of truth — and it was invisible from `sys_help`. This release unifies
+the mode routing into one registry, promotes `notebook` and
+`multi_study` to first-class routing citizens, and surfaces the whole
+axis through help. Mode names, the config enum, and every tool signature
+are unchanged, so this is backwards-compatible.
+
+### Added
+- **`sys_help(topic='modes')`** — the workspace-mode axis is now
+  discoverable from help (aliases: `mode`, `workspace_mode`). It returns
+  what mode is, the registered-mode enum (sourced from config so it
+  can't drift), a one-line role per mode, how to set it, and how routing
+  bias differs per mode. Closes the gap where the AI learned modes
+  existed only by reading `config.py`.
+- **`MODE_ROUTING` registry** in `tools/actions/router.py` — one table
+  mapping each mode to its native sub-intents, boost weight, and whether
+  it overrides the semantic router. Every mode-aware code path now reads
+  from this single source of truth instead of duplicated constants.
+
+### Improved
+- **`notebook` and `multi_study` are now first-class routing modes.**
+  They each boost their native sub-intents (`notebook_run` /
+  `program_setup`) in `tool_route`, matching the bias `tool_build` and
+  `exploration` already had. Previously they only got the weaker
+  indirect workflow-shape tiebreak, so build-shaped and analysis-shaped
+  prompts could out-rank a notebook/program protocol in those modes.
+- **The mode-override (semantic-deferral) path generalised** from
+  `tool_build`-only to any mode flagged `override=True` in the registry,
+  driven by the registry's per-mode native sub-intents.
+- **The wizard re-exports `VALID_WORKSPACE_MODES` from config** instead
+  of keeping its own copy, so the init mode menu can never offer a mode
+  the config layer would reject (drift guard).
+
+### Fixed
+- `sys_help(topic='gates')` descriptions for the `power` and
+  `assumptions` gates were stale after v3.6.0 (they still described the
+  removed statsmodels/scipy compute behaviour). They now correctly
+  describe the verify-recorded gates.
+
+---
+
 ## [3.6.0] — audit gates verify recorded work, they don't compute it (2026-06-22)
 
 A MINOR release that removes the last place a Research-OS tool did the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.6.0
+version: 3.7.0
 date-released: 2026-06-22
 keywords:
   - research-data-management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.6.0"
+version = "3.7.0"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.6.0"
+__version__ = "3.7.0"

--- a/src/research_os/server/handlers/meta_help.py
+++ b/src/research_os/server/handlers/meta_help.py
@@ -41,7 +41,7 @@ def _handle_sys_help(name, arguments, root):
             "synthesis", "methodology", "visualization", "audit",
             "literature", "writing", "routing", "iteration", "overrides",
             "recovery", "fields", "packs", "adapters", "depth", "categories",
-            "anti_patterns", "docs", "gates",
+            "anti_patterns", "docs", "gates", "modes",
         ],
         "hint": "Call sys_help again with topic=<one of topics> for detail.",
     }
@@ -402,6 +402,81 @@ def _handle_sys_help(name, arguments, root):
             "arc": "visualization/figure_narrative_arc",
             "a11y": "visualization/color_accessibility_audit",
         }))
+    if topic in {"modes", "mode", "workspace_mode"}:
+        # Workspace MODE is the top-level axis that shapes the whole project:
+        # the scaffold on disk, which protocols routing biases toward, and
+        # which audit gates apply. Set once at init (the wizard asks) or via
+        # the workspace.mode field in inputs/researcher_config.yaml. Sourcing
+        # the enum from config keeps this list from drifting.
+        from research_os.tools.actions.state.config import VALID_WORKSPACE_MODES
+        return _text(_success({
+            "what_mode_is": (
+                "Workspace MODE is the single top-level axis that shapes a "
+                "project end-to-end: (1) the directory scaffold init builds, "
+                "(2) which protocols tool_route biases toward, (3) which "
+                "audit gates apply. It is set ONCE at init and rarely changes. "
+                "analysis is the default and the universal fallback."
+            ),
+            "registered_modes": sorted(VALID_WORKSPACE_MODES),
+            "modes": {
+                "analysis": (
+                    "DEFAULT. The classic linear numbered-step workspace "
+                    "(inputs/ → workspace/NN_step/ → synthesis/). The full "
+                    "audit + literature + synthesis surface. Pick this for a "
+                    "study that produces a paper / poster / dashboard."
+                ),
+                "hybrid": (
+                    "analysis surface + tool_build governance for projects "
+                    "that BUILD a tool AND publish findings about it. Reuses "
+                    "the analysis routing surface (no separate bias) but the "
+                    "scaffold adds the spec/decisions/eval governance layer."
+                ),
+                "tool_build": (
+                    "Research OS governs a software build from above: spec/ "
+                    "(requirements + design), decisions/ (ADRs), eval/, "
+                    "milestones.md, governance.md, CHANGELOG.md, and an INNER "
+                    "git repo (workspace.inner_repo, default 'project/'). "
+                    "Routing strongly biases toward build/* protocols; build "
+                    "vocabulary that collides with analysis defers to the "
+                    "build router. Pick this when the deliverable IS the code."
+                ),
+                "exploration": (
+                    "Scratch-first quick probes with light gates. "
+                    "workspace/scratch is the home base; synthesis stays lazy. "
+                    "Routing biases toward exploration/* (loop / triage / "
+                    "promote). Pick this for an open-ended 'let me poke at "
+                    "this' session that may later promote into an analysis."
+                ),
+                "notebook": (
+                    "Jupyter-first: notebooks/ + data/ + outputs/ are eager. "
+                    "Routing biases toward notebook/* (the notebook_run "
+                    "sub-intent). Pick this for interactive iterative work "
+                    "that lives in .ipynb rather than numbered step scripts."
+                ),
+                "multi_study": (
+                    "A research PROGRAM spanning several studies: studies/ + "
+                    "shared/ (codebook, preregistration, governance) + "
+                    "roll_up/. Routing biases toward program/* (the "
+                    "program_setup sub-intent). Pick this for a portfolio of "
+                    "related studies that share methods and roll up into one "
+                    "synthesis."
+                ),
+            },
+            "how_to_set": (
+                "init: the wizard asks. Existing project: set "
+                "workspace.mode in inputs/researcher_config.yaml (one of the "
+                "registered_modes; off-enum values degrade to analysis). The "
+                "mode is mirrored into .os_state so tools and routing agree."
+            ),
+            "routing_effect": (
+                "tool_build / exploration / notebook / multi_study each boost "
+                "their native sub-intents in tool_route. analysis + hybrid "
+                "add NO bias — they use the baseline routing surface. So the "
+                "same prompt can resolve to different protocols depending on "
+                "the active mode."
+            ),
+            "inspect": "sys_boot returns the active workspace_mode for the project.",
+        }))
     if topic == "gates":
         # Full gate vocabulary — every (scope, dimension) the
         # _AUDIT_DISPATCH table can route to + the 8-gate autopilot
@@ -418,8 +493,8 @@ def _handle_sys_help(name, arguments, root):
                     "figure":               "PNG DPI + basic visual hygiene per step figure.",
                     "figure_full":          "full figure quality audit (axis, ticks, legend, colour, font).",
                     "figure_interactivity": "dashboard / interactive plot interactivity coverage.",
-                    "power":                "statistical power gate (statsmodels-driven).",
-                    "assumptions":          "residual normality / variance / autocorrelation / VIF / Cook's D battery.",
+                    "power":                "power justification gate — verifies you RECORDED test family, effect size + its source, alpha, n, target power (tool does not solve for power).",
+                    "assumptions":          "assumptions gate — verifies you RAN + recorded each named diagnostic (statistic + interpretation + response to violations); the tool does not run the tests.",
                     "reproducibility":      "step rerun + bit-stability check (slow + expensive; autopilot floor gate).",
                 },
                 "project": {

--- a/src/research_os/tools/actions/router.py
+++ b/src/research_os/tools/actions/router.py
@@ -24,7 +24,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 import yaml
 
@@ -97,53 +97,120 @@ def _collapse_hyphens(text: str) -> str:
     return re.sub(r"-+", " ", text)
 
 
-# MODE-AWARE ROUTING BIAS. When workspace_mode == 'tool_build', add this
-# to the trigger score of every build/* protocol so build-shaped prompts
-# ("add a feature", "write tests", "cut a release") reliably win over a
-# same-vocabulary analysis protocol. It's a thumb on the scale (a single
-# extra single-word match's worth), never an override: an explicit
-# cross-mode trigger ("write the paper") still out-scores the bias.
-_MODE_BUILD_BOOST = 2
+# ═══════════════════════════════════════════════════════════════════════
+# UNIFIED MODE REGISTRY — one source of truth for how each workspace mode
+# biases routing. Every mode-aware code path (the trigger-score boost, the
+# semantic-deferral override, the workflow-shape fallback) reads from this
+# table instead of hardcoding per-mode branches. Adding a mode = one entry.
+#
+# Each entry describes the routing posture of a workspace.mode:
+#   sub_intents → the protocol sub-intents NATIVE to this mode. A protocol
+#                 carrying one of these gets `boost` added to its trigger
+#                 score when the workspace is in this mode, so a mode's own
+#                 protocols reliably win over a same-vocabulary analysis
+#                 protocol. It's a thumb on the scale, never an override —
+#                 an explicit cross-mode trigger ("write the paper") still
+#                 out-scores the bias.
+#   boost       → score added to a native sub-intent's trigger score. The
+#                 tool_build family carries real risk (shipping software) so
+#                 it earns a firmer thumb (2 ≈ one extra word match); the
+#                 lighter modes nudge with 1 (a single tie-break point) since
+#                 they overlap heavily with ordinary analysis vocabulary and
+#                 we don't want to over-steer.
+#   shape       → the workspace.workflow_shape this mode implies when the
+#                 project never declares one explicitly, so the WORKFLOW-SHAPE
+#                 tiebreak can still fire. None = no clean 1:1 shape (the
+#                 experiment_pipeline shape is broad and shouldn't be
+#                 force-boosted from the default mode).
+#   override    → when True, a STRONG native-sub-intent trigger match (a
+#                 multi-word trigger, base ≥ _MODE_OVERRIDE_MIN_BASE) defers
+#                 the semantic guess to the mode-biased trigger router, so a
+#                 mode's own protocols can't be hijacked by an embedding that
+#                 leans analysis. Reserved for modes whose protocols share
+#                 vocabulary with analysis but mean something different
+#                 (build "test" ≠ analysis "test").
+#
+# analysis/hybrid carry no entry: analysis is the universal baseline and
+# hybrid deliberately reuses the analysis routing surface (it just ALSO
+# surfaces an inner tool component).
+# ═══════════════════════════════════════════════════════════════════════
+_MODE_BUILD_BOOST = 2          # firm thumb: tool_build ships real software
+_MODE_LIGHT_BOOST = 1          # tie-break nudge for the lighter modes
+_MODE_OVERRIDE_MIN_BASE = 4    # "strong" trigger = multi-word match
 
-# Sub-intents that belong to the tool_build workspace mode. Boosted when
-# workspace_mode == 'tool_build'.
-_BUILD_SUB_INTENTS = frozenset({
-    "build_spec", "build_implement", "build_test",
-    "build_benchmark", "build_release",
-})
 
-# Fallback map: when a project never declares an explicit
-# workspace.workflow_shape, infer one from workspace.mode so the
-# WORKFLOW-SHAPE tiebreak can still fire. Only modes with a clean 1:1
-# shape equivalent are mapped; "analysis"/"hybrid" map to None (the
-# experiment_pipeline shape is broad and shouldn't be force-boosted from
-# the default mode).
-_MODE_TO_SHAPE = {
-    "tool_build": "tool_build",
-    "exploration": "exploration",
-    "notebook": "notebook",
-    "multi_study": "multi_study",
+class _ModeRouting(NamedTuple):
+    sub_intents: frozenset
+    boost: int
+    shape: str | None
+    override: bool
+
+
+MODE_ROUTING: dict[str, _ModeRouting] = {
+    # Building software you iterate on. Native build/* family; firm boost;
+    # overrides the semantic guess on a strong build trigger because build
+    # vocabulary ("test", "release", "benchmark") collides with analysis.
+    "tool_build": _ModeRouting(
+        sub_intents=frozenset({
+            "build_spec", "build_implement", "build_test",
+            "build_benchmark", "build_release",
+        }),
+        boost=_MODE_BUILD_BOOST,
+        shape="tool_build",
+        override=True,
+    ),
+    # Scratch-first quick probes. Native exploration/* loop (probe → observe
+    # → decide, triage, promote) plus the analysis-mode lightweight surfaces
+    # (casual / eda) it can fall back to. Light nudge — exploration overlaps
+    # heavily with ordinary analysis vocabulary.
+    "exploration": _ModeRouting(
+        sub_intents=frozenset({
+            "casual", "eda",
+            "explore_probe", "explore_promote", "explore_triage",
+        }),
+        boost=_MODE_LIGHT_BOOST,
+        shape="exploration",
+        override=False,
+    ),
+    # Jupyter-first: the unit of work is a notebook. Native notebook_run plus
+    # eda (notebooks are the natural home for exploratory data analysis).
+    # First-class boost so "run the notebook" leans notebook-shaped rather
+    # than dropping into a numbered analysis step.
+    "notebook": _ModeRouting(
+        sub_intents=frozenset({"notebook_run", "eda"}),
+        boost=_MODE_LIGHT_BOOST,
+        shape="notebook",
+        override=False,
+    ),
+    # A program of sub-studies sharing a codebook + prereg. Native
+    # program_setup so "set up the program" reliably reaches the program
+    # commons protocol rather than a single-study planning protocol.
+    "multi_study": _ModeRouting(
+        sub_intents=frozenset({"program_setup"}),
+        boost=_MODE_LIGHT_BOOST,
+        shape="multi_study",
+        override=False,
+    ),
 }
 
-# EXPLORATION-mode bias. exploration workspaces are scratch-first quick
-# probes — when in that mode, nudge the lightweight / open-ended
-# protocols (casual exploration + open-ended EDA) so an ambiguous
-# "let me poke at this" leans probe-shaped rather than committing to a
-# heavyweight confirmatory loop. Smaller than the build boost: a single
-# tie-break point, since exploration overlaps heavily with normal
-# analysis vocabulary and we don't want to over-steer.
-_EXPLORATION_BOOST = 1
+# Back-compat aliases (external importers may reference the old names).
+_BUILD_SUB_INTENTS = MODE_ROUTING["tool_build"].sub_intents
+_EXPLORATION_SUB_INTENTS = MODE_ROUTING["exploration"].sub_intents
+_EXPLORATION_BOOST = _MODE_LIGHT_BOOST
 
-# Sub-intents that are "quick / scratch / exploratory" shaped. Boosted
-# when workspace_mode == 'exploration'. Includes the native exploration/*
-# family (probe → observe → decide loop, triage, promote) so an
-# exploration-mode workspace leans on its own scratch-first protocols, plus
-# the analysis-mode lightweight surfaces (casual / eda) it can still fall
-# back to.
-_EXPLORATION_SUB_INTENTS = frozenset({
-    "casual", "eda",
-    "explore_probe", "explore_promote", "explore_triage",
-})
+# Fallback map: workspace.mode → implied workflow_shape (derived from the
+# registry; kept as a dict for the existing callers).
+_MODE_TO_SHAPE = {m: r.shape for m, r in MODE_ROUTING.items() if r.shape}
+
+
+def _mode_boost_for(workspace_mode: str, sub_intent: str | None) -> int:
+    """Score boost a protocol earns for matching the active mode's native
+    sub-intents. 0 when the mode has no registry entry (analysis/hybrid) or
+    the protocol isn't native to the mode. Single source for the bias."""
+    entry = MODE_ROUTING.get(workspace_mode)
+    if entry is None or sub_intent is None:
+        return 0
+    return entry.boost if sub_intent in entry.sub_intents else 0
 
 # WORKFLOW-SHAPE TIEBREAK. A light nudge (half the size of a single
 # trigger-word match, so it can only break a tie, never flip a real
@@ -455,24 +522,28 @@ def _try_semantic_route(
     if not semantic.semantic_available():
         return None
 
-    # MODE override (tool_build): if a build/* protocol has a strong
-    # trigger match, defer to the mode-biased trigger router rather than
-    # the semantic guess. "Strong" = a multi-word trigger (base ≥ 4) so a
-    # single stray build word doesn't hijack an analysis prompt.
-    if workspace_mode == "tool_build":
+    # MODE override (registry-driven): if the active mode is marked
+    # override=True and one of its NATIVE-sub-intent protocols has a strong
+    # trigger match, defer to the mode-biased trigger router rather than the
+    # semantic guess. "Strong" = a multi-word trigger (base ≥
+    # _MODE_OVERRIDE_MIN_BASE) so a single stray mode word doesn't hijack an
+    # analysis prompt. Today only tool_build opts in (build vocabulary
+    # collides with analysis), but any future mode can by setting override.
+    _mode_entry = MODE_ROUTING.get(workspace_mode)
+    if _mode_entry is not None and _mode_entry.override:
         # Normalize identically to the main path (the old inline form missed
         # the hyphen collapse, so 'agent-based' never matched 'agent based').
         prompt_norm = _normalize_prompt(prompt)
-        build_scored = [
+        native_scored = [
             s for s in _score_protocols(
                 prompt_norm, protocols,
                 workspace_mode=workspace_mode,
                 project_workflow_shape=project_workflow_shape,
             )
-            if (s["data"].get("sub_intent") in _BUILD_SUB_INTENTS)
-            and s.get("base_score", 0) >= 4
+            if (s["data"].get("sub_intent") in _mode_entry.sub_intents)
+            and s.get("base_score", 0) >= _MODE_OVERRIDE_MIN_BASE
         ]
-        if build_scored:
+        if native_scored:
             return None
 
     sem = semantic.semantic_route(prompt, k=5)
@@ -1921,13 +1992,11 @@ def _score_protocols(
         if score <= 0:
             continue
         base_score = score
-        # ── MODE bias (build/* or exploration probes) ─────────────────
-        mode_boost = 0
+        # ── MODE bias (registry-driven) ───────────────────────────────
+        # Each workspace mode boosts its NATIVE sub-intents (one source of
+        # truth: MODE_ROUTING). analysis/hybrid have no entry → no boost.
         sub = data.get("sub_intent")
-        if workspace_mode == "tool_build" and sub in _BUILD_SUB_INTENTS:
-            mode_boost = _MODE_BUILD_BOOST
-        elif workspace_mode == "exploration" and sub in _EXPLORATION_SUB_INTENTS:
-            mode_boost = _EXPLORATION_BOOST
+        mode_boost = _mode_boost_for(workspace_mode, sub)
         # ── WORKFLOW-SHAPE tiebreak ───────────────────────────────────
         shape_boost = 0
         if project_workflow_shape:

--- a/src/research_os/wizard.py
+++ b/src/research_os/wizard.py
@@ -434,9 +434,12 @@ def run_wizard(args) -> WizardResult:
 # ---------------------------------------------------------------------------
 
 
-VALID_WORKSPACE_MODES = (
-    "analysis", "tool_build", "exploration", "notebook", "multi_study",
-    "hybrid",
+# Single source of truth lives in tools.actions.state.config — re-export it
+# here so the wizard's mode menu can never offer a mode the config layer
+# would later reject (drift guard). Imported lazily-safe at module load:
+# config is a leaf state module with no back-edge to the wizard.
+from research_os.tools.actions.state.config import (  # noqa: E402
+    VALID_WORKSPACE_MODES,
 )
 
 

--- a/tests/unit/test_sys_help_modes_topic.py
+++ b/tests/unit/test_sys_help_modes_topic.py
@@ -1,0 +1,77 @@
+"""v3.7.0: sys_help(topic='modes') — workspace-mode discoverability.
+
+Before this slice the workspace MODE axis (analysis / hybrid / tool_build /
+exploration / notebook / multi_study) was completely undiscoverable from
+sys_help — the AI learned it existed only by reading config.py. The 'modes'
+topic returns:
+  * what the mode axis is (scaffold + routing + audits)
+  * the registered-mode enum (sourced from config, can't drift)
+  * a 1-line role per mode
+  * how to set it + how routing bias differs per mode
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from research_os.server import _handle_tool_call
+
+
+@pytest.fixture
+def project_root(tmp_path):
+    (tmp_path / ".os_state").mkdir()
+    (tmp_path / "workspace").mkdir()
+    return tmp_path
+
+
+def _payload(result):
+    assert isinstance(result, list) and result, f"unexpected: {result!r}"
+    env = json.loads(result[0].text)
+    assert env["status"] == "success", env
+    return env["data"]
+
+
+def test_modes_topic_listed_in_topics_index(project_root):
+    """sys_help with no topic must advertise 'modes' so the AI can find it."""
+    res = _handle_tool_call("sys_help", {}, project_root)
+    data = _payload(res)
+    assert "modes" in data["topics"]
+
+
+def test_modes_topic_returns_every_registered_mode(project_root):
+    """The topic documents every VALID_WORKSPACE_MODE — enum sourced from
+    config so the help text can't silently fall behind a new mode."""
+    from research_os.tools.actions.state.config import VALID_WORKSPACE_MODES
+
+    res = _handle_tool_call("sys_help", {"topic": "modes"}, project_root)
+    data = _payload(res)
+
+    assert set(data["registered_modes"]) == set(VALID_WORKSPACE_MODES)
+    # Every registered mode has a non-empty 1-line role.
+    for mode in VALID_WORKSPACE_MODES:
+        assert mode in data["modes"], f"modes topic missing role for {mode}"
+        assert data["modes"][mode].strip(), f"{mode} role is empty"
+
+
+def test_modes_topic_explains_axis_and_routing(project_root):
+    res = _handle_tool_call("sys_help", {"topic": "modes"}, project_root)
+    data = _payload(res)
+    for key in ("what_mode_is", "how_to_set", "routing_effect", "inspect"):
+        assert key in data and data[key].strip(), f"missing {key}"
+    # The routing_effect must name the biased modes vs the neutral ones.
+    eff = data["routing_effect"]
+    for biased in ("tool_build", "exploration", "notebook", "multi_study"):
+        assert biased in eff
+    assert "analysis" in eff and "hybrid" in eff
+
+
+def test_modes_topic_aliases_resolve(project_root):
+    """'mode' and 'workspace_mode' resolve to the same topic as 'modes'."""
+    base = _payload(_handle_tool_call("sys_help", {"topic": "modes"},
+                                      project_root))
+    for alias in ("mode", "workspace_mode"):
+        alt = _payload(_handle_tool_call("sys_help", {"topic": alias},
+                                         project_root))
+        assert alt["registered_modes"] == base["registered_modes"]

--- a/tests/unit/test_workspace_modes.py
+++ b/tests/unit/test_workspace_modes.py
@@ -352,3 +352,77 @@ def test_unknown_mode_still_falls_back_to_analysis_byte_identical():
         for leaked in ("notebooks", "studies", "shared", "roll_up", "spec",
                        "data", "outputs"):
             assert not (b / leaked).exists(), f"fallback leaked {leaked}"
+
+
+# ---------------------------------------------------------------------------
+# Mode routing registry — the single source of truth that biases routing.
+# Every mode-aware code path reads from MODE_ROUTING; these tests lock the
+# contract so notebook / multi_study stay first-class and analysis / hybrid
+# stay neutral.
+# ---------------------------------------------------------------------------
+
+
+def test_mode_routing_registry_covers_every_biased_mode():
+    """Every non-baseline mode (all VALID modes except analysis + hybrid,
+    which deliberately reuse the analysis routing surface) has a registry
+    entry. This is what makes notebook + multi_study first-class instead of
+    relying only on the indirect workflow-shape tiebreak."""
+    from research_os.tools.actions.router import MODE_ROUTING
+    from research_os.tools.actions.state.config import VALID_WORKSPACE_MODES
+    baseline = {"analysis", "hybrid"}
+    biased = set(VALID_WORKSPACE_MODES) - baseline
+    assert biased == set(MODE_ROUTING), (
+        f"registry/enum drift: enum-biased={biased} registry={set(MODE_ROUTING)}"
+    )
+
+
+def test_mode_boost_is_registry_driven_for_every_native_sub_intent():
+    """Each registry mode boosts EVERY one of its own native sub-intents by
+    exactly its declared boost, and zero for a sub-intent it doesn't own."""
+    from research_os.tools.actions.router import MODE_ROUTING, _mode_boost_for
+    for mode, entry in MODE_ROUTING.items():
+        for sub in entry.sub_intents:
+            assert _mode_boost_for(mode, sub) == entry.boost, (
+                f"{mode}/{sub} boost != {entry.boost}"
+            )
+        # A sub-intent guaranteed not to be native to this mode.
+        assert _mode_boost_for(mode, "__not_a_real_sub_intent__") == 0
+
+
+def test_notebook_and_multi_study_are_first_class():
+    """The fix this release ships: notebook + multi_study now carry a real
+    routing boost on their native sub-intents (notebook_run / program_setup),
+    not just the indirect shape tiebreak."""
+    from research_os.tools.actions.router import _mode_boost_for
+    assert _mode_boost_for("notebook", "notebook_run") > 0
+    assert _mode_boost_for("multi_study", "program_setup") > 0
+
+
+def test_analysis_and_hybrid_get_no_mode_boost():
+    """analysis is the universal baseline; hybrid reuses the analysis routing
+    surface. Neither may boost ANY sub-intent — that would silently re-rank
+    the default workspace."""
+    from research_os.tools.actions.router import MODE_ROUTING, _mode_boost_for
+    every_sub = {s for e in MODE_ROUTING.values() for s in e.sub_intents}
+    for mode in ("analysis", "hybrid"):
+        for sub in every_sub | {"eda", "casual", "notebook_run"}:
+            assert _mode_boost_for(mode, sub) == 0, f"{mode} boosted {sub}"
+
+
+def test_tool_build_is_the_only_override_mode():
+    """Only tool_build defers the semantic guess on a strong native trigger
+    (build vocabulary collides with analysis). The lighter modes nudge but
+    never override — guards against an over-steering regression."""
+    from research_os.tools.actions.router import MODE_ROUTING
+    overriding = {m for m, e in MODE_ROUTING.items() if e.override}
+    assert overriding == {"tool_build"}
+
+
+def test_mode_to_shape_derives_from_registry():
+    """The mode→workflow_shape fallback map is derived from the registry, so
+    a mode can't declare a shape in one place and a boost in another and
+    drift. Every biased mode with a shape appears in the derived map."""
+    from research_os.tools.actions.router import MODE_ROUTING, _MODE_TO_SHAPE
+    expected = {m: e.shape for m, e in MODE_ROUTING.items() if e.shape}
+    assert _MODE_TO_SHAPE == expected
+


### PR DESCRIPTION
Unifies workspace-mode routing into a single MODE_ROUTING registry, promotes notebook + multi_study to first-class routing modes, adds sys_help(topic='modes') discoverability, fixes stale gates-topic text, and makes the wizard re-export VALID_WORKSPACE_MODES from config. Backwards-compatible MINOR. Gate green: ruff clean, preflight 33/33, version-chatter 0, 2302 passed/13 skipped. See CHANGELOG [3.7.0].