### PR TITLE
v3.8.0 — adaptive-primary autonomy gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.8.0] — adaptive-primary autonomy gates (2026-06-22)
+
+A MINOR release that makes the **adaptive** autonomy mode visibly primary
+across the protocol catalogue and tightens every autonomy gate. No behaviour
+changes — same modes, same tools, same floors — just a clearer, leaner gate
+idiom plus better protocol connectivity.
+
+### Improved
+
+- **Autonomy gates collapsed to two behaviour lines.** Every `AUTONOMY GATE`
+  block used to spell out four modes (`adaptive (default) →`, `manual /
+  supervised →`, `autopilot →`), restating the proceed-path twice because
+  adaptive and autopilot almost always said the same thing. All 28 well-formed
+  gate blocks now lead with a single primary line —
+  `proceed (adaptive default, autopilot) →` — followed by
+  `confirm first (manual / supervised) →`. This makes adaptive the obvious
+  default instead of one of four co-equal options, and trims ~40% of each
+  gate's prose.
+- **Autopilot nuance preserved inline.** In the three blocks where autopilot
+  legitimately bypassed a confirm-floor that adaptive honours
+  (`build/spec_and_design`, `build/test_strategy`,
+  `build/release_and_changelog`), that deviation is kept as a parenthetical
+  "(Under autopilot, …)" clause rather than dropped — no floor is lost in the
+  collapse.
+- **Protocol connectivity.** Linked the two genuinely orphaned guidance
+  protocols: `glossary_update` now `see_also` writing_core + analysis_plan;
+  `hypothesis_tracking` now `see_also` analysis_plan + research_design +
+  synthesis_paper. (The rest of the catalogue already resolved cleanly —
+  preflight's `check_routing_targets_resolve` continues to guard against
+  dangling `see_also` / `next_protocol` pointers.)
+
+### Added
+
+- `tests/unit/test_gate_idiom_collapsed.py` — locks the collapsed gate idiom
+  catalogue-wide (no verbose four-mode lines survive, every proceed-line has a
+  matching confirm-line, autopilot nuance preserved in the three special
+  blocks).
+
+### Bumped
+
+- Version → 3.8.0 (`pyproject.toml`, `__init__.py`, `CITATION.cff`).
+- `version:` field on the 20 touched protocol YAMLs → 3.8.0.
+
+---
+
 ## [3.7.0] — first-class workspace modes (2026-06-22)
 
 A MINOR release that makes the workspace **mode** axis coherent and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.7.0
+version: 3.8.0
 date-released: 2026-06-22
 keywords:
   - research-data-management

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.7.0"
+version = "3.8.0"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.7.0"
+__version__ = "3.8.0"

--- a/src/research_os/protocols/build/benchmark_vs_baseline.yaml
+++ b/src/research_os/protocols/build/benchmark_vs_baseline.yaml
@@ -1,7 +1,7 @@
 id: benchmark_vs_baseline
 tier: 'execute'
 name: Benchmark vs Baseline (fair measurement against the right comparator)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -118,14 +118,12 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — recording a verdict changes no artefact that
         can't be re-judged; the real hazard is overclaiming on noise.
-        adaptive (default) → record the verdict with its evidence and flag
+        proceed (adaptive default, autopilot) → record the verdict with its evidence and flag
           any claim that rests on a within-noise difference; surface the
           call to the researcher when the result reverses a prior claim or
           drives an irreversible downstream decision.
-        manual / supervised → present the result + uncertainty + your
+        confirm first (manual / supervised) → present the result + uncertainty + your
           read; let the researcher judge whether the claim holds.
-        autopilot → record the verdict with its evidence and flag any
-          claim that rests on a within-noise difference.
 
 expected_outputs:
   - eval/ benchmark harness + results (with conditions + versions pinned)

--- a/src/research_os/protocols/build/implement_iteration.yaml
+++ b/src/research_os/protocols/build/implement_iteration.yaml
@@ -1,7 +1,7 @@
 id: implement_iteration
 tier: 'execute'
 name: Implement Iteration (the inner build loop)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -73,11 +73,10 @@ steps:
 
       AUTONOMY GATE:
         Risk: reversible + cheap — scoping an increment writes no code yet.
-        adaptive (default) → state the increment scope and proceed to
+        proceed (adaptive default, autopilot) → state the increment scope and proceed to
           implement; nothing here needs confirmation.
-        manual / supervised → present the increment scope; confirm before
+        confirm first (manual / supervised) → present the increment scope; confirm before
           writing code.
-        autopilot → state the scope and proceed.
 
   - id: implement
     name: Implement the increment in the inner repo
@@ -174,11 +173,10 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — a local commit is undoable (amend, revert, reset)
         and pushes nothing on its own.
-        adaptive (default) → commit with a well-formed message and log it;
+        proceed (adaptive default, autopilot) → commit with a well-formed message and log it;
           no confirmation needed for a local commit.
-        manual / supervised → show the diff summary + proposed commit
+        confirm first (manual / supervised) → show the diff summary + proposed commit
           message; commit on confirmation.
-        autopilot → commit with a well-formed message; log it.
 
   - id: record_and_decide
     name: Record the change + decide the next increment
@@ -207,14 +205,11 @@ steps:
       AUTONOMY GATE:
         Risk: reversible + cheap — looping to the next increment is just
         more gated build work; the weight sits in the gates it re-enters.
-        adaptive (default) → if the build is green and no risk flag fired,
+        proceed (adaptive default, autopilot) → if the build is green and no risk flag fired,
           loop back to scope_increment for the next increment in the SAME
           turn; if a risk flag fired or the build is red, pause and present.
-        manual / supervised → present the increment summary + the candidate
+        confirm first (manual / supervised) → present the increment summary + the candidate
           next increments; wait for the choice.
-        autopilot → if the build is green and no risk flag fired, loop back
-          to scope_increment for the next increment in the SAME turn;
-          otherwise pause and present.
 
   - id: handoff_when_long
     name: Hand off when the build context gets long

--- a/src/research_os/protocols/build/release_and_changelog.yaml
+++ b/src/research_os/protocols/build/release_and_changelog.yaml
@@ -1,7 +1,7 @@
 id: release_and_changelog
 tier: 'finalize'
 name: Release & Changelog (cut a versioned, reproducible release)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -74,14 +74,12 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — choosing the bump and writing the CHANGELOG
         changes nothing published; it can be re-edited before the tag.
-        adaptive (default) → choose the bump, state the reasoning (which
+        proceed (adaptive default, autopilot) → choose the bump, state the reasoning (which
           commits forced major vs minor vs patch), and proceed; flag any
           commit whose classification was ambiguous.
-        manual / supervised → present the proposed bump + the reasoning
+        confirm first (manual / supervised) → present the proposed bump + the reasoning
           (which commits forced major vs minor vs patch); confirm before
           tagging.
-        autopilot → choose the bump, state the reasoning, and proceed; flag
-          any commit whose classification was ambiguous.
 
   - id: write_changelog
     name: Write the changelog FROM the commit history
@@ -158,16 +156,15 @@ steps:
       AUTONOMY GATE:
         Risk: publishing to an external registry is irreversible — a
         published version can't be unpublished; tagging is local and cheap.
-        adaptive (default) → tag and build the artefact locally; PAUSE
+        proceed (adaptive default, autopilot) → tag and build the artefact locally; PAUSE
           before any PUBLISH to an external registry (PyPI, npm, a public
           release) and confirm, because that step can't be undone. This is
-          a hard floor, not a judgement call.
-        manual / supervised → present the version + changelog + artefact
+          a hard floor, not a judgement call. (Under autopilot, pause before
+          any PUBLISH to an external registry unless the researcher opted
+          into autopilot publishing.)
+        confirm first (manual / supervised) → present the version + changelog + artefact
           plan; tag and publish only on explicit confirmation (publishing is
           hard to undo).
-        autopilot → tag and build the artefact; pause before any PUBLISH to
-          an external registry unless the researcher opted into autopilot
-          publishing.
 
 expected_outputs:
   - A version bump in the project's single source of truth

--- a/src/research_os/protocols/build/spec_and_design.yaml
+++ b/src/research_os/protocols/build/spec_and_design.yaml
@@ -1,7 +1,7 @@
 id: spec_and_design
 tier: 'plan'
 name: Spec & Design (what the tool must do, and how "done" is judged)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -129,16 +129,16 @@ steps:
       AUTONOMY GATE:
         Risk: irreversible — load-bearing choices ripple through everything
         built on them, so reversing one later is expensive.
-        adaptive (default) → for choices that are genuinely hard to reverse,
+        proceed (adaptive default, autopilot) → for choices that are genuinely hard to reverse,
           present the load-bearing decisions + your recommendation and
           confirm before writing the ADRs as 'accepted'; for a choice that
           is cheap to revisit, write it and move on. Judge from how far the
-          choice ripples, not from a fixed rule.
-        manual / supervised → present the load-bearing decisions + your
+          choice ripples, not from a fixed rule. (Under autopilot, write the
+          ADRs with status 'accepted' and a clear rationale; log them so a
+          later review can challenge any one.)
+        confirm first (manual / supervised) → present the load-bearing decisions + your
           recommendation; ask the researcher to confirm before writing the
           ADRs as 'accepted'.
-        autopilot → write the ADRs with status 'accepted' and a clear
-          rationale; log them so a later review can challenge any one.
 
   - id: ground_design
     name: Ground non-trivial design choices in prior art
@@ -189,12 +189,10 @@ steps:
       AUTONOMY GATE:
         Risk: reversible + cheap — entering the build loop commits nothing
         that can't be unwound; the first increment is itself gated.
-        adaptive (default) → proceed to build/implement_iteration on the
+        proceed (adaptive default, autopilot) → proceed to build/implement_iteration on the
           first milestone; the loop's own gates catch anything weighty.
-        manual / supervised → present the spec summary + proposed first
+        confirm first (manual / supervised) → present the spec summary + proposed first
           milestone; wait for the researcher before entering the loop.
-        autopilot → proceed to build/implement_iteration on the first
-          milestone.
 
 expected_outputs:
   - spec/requirements.md

--- a/src/research_os/protocols/build/test_strategy.yaml
+++ b/src/research_os/protocols/build/test_strategy.yaml
@@ -1,7 +1,7 @@
 id: test_strategy
 tier: 'plan'
 name: Test Strategy (the testing regime that fits THIS tool)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [engineering, any]
@@ -127,12 +127,12 @@ steps:
       AUTONOMY GATE:
         Risk: reversible but shared — CI config is undoable, but it governs
         everyone's merges, so a bad gate blocks the whole team.
-        adaptive (default) → wire the regime and log the rationale; if the
+        proceed (adaptive default, autopilot) → wire the regime and log the rationale; if the
           CI gate would block merges for collaborators other than yourself,
           present it first. Judge from blast radius, not from a fixed rule.
-        manual / supervised → present the proposed regime + CI gate; wait
+          (Under autopilot, wire it and log the rationale.)
+        confirm first (manual / supervised) → present the proposed regime + CI gate; wait
           for confirmation before wiring CI (it governs everyone's merges).
-        autopilot → wire it and log the rationale.
 
 expected_outputs:
   - The inner repo's test suite + runner config

--- a/src/research_os/protocols/exploration/exploration_loop.yaml
+++ b/src/research_os/protocols/exploration/exploration_loop.yaml
@@ -1,7 +1,7 @@
 id: exploration_loop
 tier: 'execute'
 name: Exploration Loop (probe → observe → decide)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -139,13 +139,11 @@ steps:
       AUTONOMY GATE:
         Risk: reversible + cheap — every probe lives in scratch and a
         promote/drop/iterate call commits nothing that can't be redone.
-        adaptive (default) → act on the decision; if promoting, say so and
+        proceed (adaptive default, autopilot) → act on the decision; if promoting, say so and
           load exploration_promote in the same turn.
-        manual / supervised → present the observation + your recommended
+        confirm first (manual / supervised) → present the observation + your recommended
           decision (promote / drop / iterate) and the next probe if
           iterating; wait for the researcher.
-        autopilot → act on the decision; if promoting, say so and load
-          exploration_promote in the same turn.
 
       Log nothing heavyweight here. mem_log is reserved for a genuinely
       surprising finding the researcher wants kept — in exploration mode

--- a/src/research_os/protocols/exploration/exploration_promote.yaml
+++ b/src/research_os/protocols/exploration/exploration_promote.yaml
@@ -1,7 +1,7 @@
 id: exploration_promote
 tier: 'execute'
 name: Promote a Probe to a Real Step
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -60,12 +60,10 @@ steps:
       AUTONOMY GATE:
         Risk: reversible + cheap — promote-or-iterate keeps work in scratch
         until it's earned a real step; nothing here is hard to undo.
-        adaptive (default) → if the observation is reproducible and
+        proceed (adaptive default, autopilot) → if the observation is reproducible and
           material, promote; otherwise iterate once more in scratch.
-        manual / supervised → state your recommendation (promote / one
+        confirm first (manual / supervised) → state your recommendation (promote / one
           more probe) and wait for the researcher.
-        autopilot → if the observation is reproducible and material,
-          promote; otherwise iterate once more in scratch.
 
   - id: state_the_hypothesis
     name: Turn the probe's question into a hypothesis
@@ -133,10 +131,9 @@ steps:
       AUTONOMY GATE:
         Risk: reversible + cheap — entering analysis_plan on the new step
         runs no expensive or irreversible action by itself.
-        adaptive (default) → proceed into analysis_plan on the new step.
-        manual / supervised → present the new step + the planned
+        proceed (adaptive default, autopilot) → proceed into analysis_plan on the new step.
+        confirm first (manual / supervised) → present the new step + the planned
           analysis_plan entry; wait before running the loop.
-        autopilot → proceed into analysis_plan on the new step.
 
 expected_outputs:
   - workspace/<NN_slug>/  (the promoted numbered step)

--- a/src/research_os/protocols/exploration/exploration_triage.yaml
+++ b/src/research_os/protocols/exploration/exploration_triage.yaml
@@ -1,7 +1,7 @@
 id: exploration_triage
 tier: 'plan'
 name: Exploration Triage (what's cheaply worth probing first)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -96,12 +96,10 @@ steps:
       AUTONOMY GATE:
         Risk: reversible + cheap — running the top probe is scratch work
         and the backlog stays available to reorder later.
-        adaptive (default) → run the top probe via exploration_loop; keep
+        proceed (adaptive default, autopilot) → run the top probe via exploration_loop; keep
           the rest as the backlog.
-        manual / supervised → present the ranked list; let the researcher
+        confirm first (manual / supervised) → present the ranked list; let the researcher
           pick which probe to run first (they may reorder).
-        autopilot → run the top probe via exploration_loop; keep the rest
-          as the backlog.
 
 expected_outputs:
   - workspace/scratch/triage.md  (the ranked probe backlog)

--- a/src/research_os/protocols/guidance/analysis_plan.yaml
+++ b/src/research_os/protocols/guidance/analysis_plan.yaml
@@ -1,7 +1,7 @@
 id: analysis_plan
 tier: 'execute'
 name: Analysis Plan (Core Loop)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -57,9 +57,8 @@ steps:
 
       AUTONOMY GATE:
         Risk: reversible + cheap — scoping the step writes no analysis yet.
-        adaptive (default) → state the scope and proceed; do NOT ask.
-        manual / supervised → present the scope; ask for confirmation.
-        autopilot           → state the scope and proceed; do NOT ask.
+        proceed (adaptive default, autopilot) → state the scope and proceed; do NOT ask.
+        confirm first (manual / supervised) → present the scope; ask for confirmation.
 
       SIZE GATE: if scope mentions >3 distinct methods OR multiple subgroups
       OR custom pipelines, you MUST call tool_plan_step before coding. The
@@ -222,16 +221,12 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — a step-intent classification is logged and can
         be re-labelled; nothing downstream is locked by it.
-        adaptive (default) → pick the closest fit and proceed; log the
+        proceed (adaptive default, autopilot) → pick the closest fit and proceed; log the
           rationale in workspace/logs/step_intent_choices.md so a later
           audit can review it.
-        manual / supervised → suggest the classification; ask for
+        confirm first (manual / supervised) → suggest the classification; ask for
                               confirmation when ambiguous (e.g. a
                               step that fits BOTH analyse + visualise).
-        autopilot           → pick the closest fit and proceed; log
-                              the rationale in workspace/logs/
-                              step_intent_choices.md so a later audit
-                              can replay it.
 
   - id: create_step_folder
     name: Create the Numbered Experiment Folder
@@ -806,17 +801,12 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — presenting results and choosing the next step
         commits nothing irreversible; the concern is researcher steering.
-        adaptive (default) → present the summary + options; if
+        proceed (adaptive default, autopilot) → present the summary + options; if
                               would_benefit_from_revision is False AND
                               audit warnings == 0, proceed to decide_next
                               in the SAME turn. Otherwise surface the
                               decision and wait for the researcher.
-        manual / supervised → wait for the researcher's reply (a/b/c/d).
-        autopilot           → present the summary + options; if
-                              would_benefit_from_revision is False
-                              AND audit warnings == 0, proceed to
-                              decide_next in the SAME turn. Otherwise
-                              still wait for the researcher.
+        confirm first (manual / supervised) → wait for the researcher's reply (a/b/c/d).
 
       ONE-SHOT GUARD: if the AI calls `sys_path` immediately
       after `tool_path_finalize` without calling
@@ -851,13 +841,10 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — the choice was already surfaced in
         present_to_researcher; this just acts on it.
-        adaptive (default) → proceed to the chosen action (already decided
+        proceed (adaptive default, autopilot) → proceed to the chosen action (already decided
           in present_to_researcher).
-        manual / supervised → wait for the explicit answer from
+        confirm first (manual / supervised) → wait for the explicit answer from
                               `present_to_researcher`.
-        autopilot           → already-confirmed in
-                              `present_to_researcher`; proceed to the
-                              chosen action.
 
       Log the decision as a ReAct trace entry so future audit can
       reconstruct WHY each step branched / proceeded / died:

--- a/src/research_os/protocols/guidance/glossary_update.yaml
+++ b/src/research_os/protocols/guidance/glossary_update.yaml
@@ -1,7 +1,7 @@
 id: glossary_update
 tier: 'plan'
 name: Glossary Update
-version: '3.0.0'
+version: '3.8.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -10,6 +10,9 @@ scope_tags:
   workflow_shape: [any]
 description: Add or refine a definition in docs/glossary.md. Run this protocol the first time any non-trivial term appears in the project.
 trigger: A jargon term, acronym, or domain-specific concept appears in methods/analysis/conclusions for the first time.
+see_also:
+  - writing/writing_core
+  - guidance/analysis_plan
 
 steps:
   - id: identify_terms

--- a/src/research_os/protocols/guidance/hypothesis_tracking.yaml
+++ b/src/research_os/protocols/guidance/hypothesis_tracking.yaml
@@ -1,7 +1,7 @@
 id: hypothesis_tracking
 tier: 'plan'
 name: Hypothesis Tracking
-version: '3.0.0'
+version: '3.8.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -10,6 +10,10 @@ scope_tags:
   workflow_shape: [any]
 description: Maintain a clear ledger of active, supported, and refuted hypotheses across the project.
 trigger: Whenever a step generates evidence that confirms / disconfirms / refines a hypothesis.
+see_also:
+  - guidance/analysis_plan
+  - domain/research_design
+  - synthesis/synthesis_paper
 
 steps:
   - id: record_hypothesis

--- a/src/research_os/protocols/guidance/iterative_planning.yaml
+++ b/src/research_os/protocols/guidance/iterative_planning.yaml
@@ -1,7 +1,7 @@
 id: iterative_planning
 tier: 'plan'
 name: Iterative Planning
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -59,11 +59,9 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — picking a plan option commits nothing; the
         researcher can redirect at any time.
-        adaptive (default) → pick OPTION A (your top choice), tell the
+        proceed (adaptive default, autopilot) → pick OPTION A (your top choice), tell the
                               researcher "I'm going with A — say stop to switch".
-        manual / supervised → wait for the researcher to choose.
-        autopilot           → pick OPTION A (your top choice), tell the
-                              researcher "I'm going with A — say stop to switch".
+        confirm first (manual / supervised) → wait for the researcher to choose.
 
       AMBIGUITY POSTURE GATE:
         ask_when_uncertain → ask + wait when 2+ options are within

--- a/src/research_os/protocols/guidance/mid_pipeline_entry.yaml
+++ b/src/research_os/protocols/guidance/mid_pipeline_entry.yaml
@@ -1,7 +1,7 @@
 id: mid_pipeline_entry
 tier: 'intake'
 name: Mid-Pipeline Entry (entering an in-progress project)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -86,16 +86,11 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — inferring the entry state reads files and
         confirms; it changes nothing on its own.
-        adaptive (default) → infer from sys_file_list across inputs/,
+        proceed (adaptive default, autopilot) → infer from sys_file_list across inputs/,
                               workspace/, docs/, plus any non-RO folders
                               the researcher hints at; assume the
                               maximum-plausible state and confirm in one line.
-        manual / supervised → wait for the researcher.
-        autopilot           → infer from sys_file_list across inputs/,
-                              workspace/, docs/, plus any non-RO
-                              folders the researcher hints at; assume
-                              the maximum-plausible state and confirm
-                              in one line.
+        confirm first (manual / supervised) → wait for the researcher.
 
   - id: classify_the_entry_point
     name: Classify the entry point

--- a/src/research_os/protocols/guidance/scope_clarification.yaml
+++ b/src/research_os/protocols/guidance/scope_clarification.yaml
@@ -1,7 +1,7 @@
 id: scope_clarification
 tier: 'intake'
 name: Scope Clarification (vague intent → workable scope)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -131,12 +131,9 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — choosing how to read an ambiguous scope commits
         nothing; the researcher can redirect.
-        adaptive (default) → pick the highest-likelihood option, state it,
+        proceed (adaptive default, autopilot) → pick the highest-likelihood option, state it,
                               and proceed with "say stop to redirect".
-        manual / supervised → ask + wait.
-        autopilot           → pick the highest-likelihood option,
-                              state it, and proceed with "say stop to
-                              redirect".
+        confirm first (manual / supervised) → ask + wait.
 
       AMBIGUITY POSTURE GATE:
         ask_when_uncertain → ask + wait (default).

--- a/src/research_os/protocols/methodology/deep_domain_research.yaml
+++ b/src/research_os/protocols/methodology/deep_domain_research.yaml
@@ -1,7 +1,7 @@
 id: deep_domain_research
 tier: 'plan'
 name: Deep Domain Research (subfield-canonical pipeline)
-version: '3.5.0'
+version: '3.8.0'
 last_reviewed: '2026-06-16'
 schema_version: '2.0'
 scope_tags:
@@ -227,14 +227,10 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — switching to an alternative method changes the
         plan, not any committed result; the guard is reporting consistency.
-        adaptive (default) → only branch if the tool returned
+        proceed (adaptive default, autopilot) → only branch if the tool returned
           `branch_to_alternative` AND the alternative does not change the
           primary reporting standard; otherwise present and wait.
-        manual / supervised → present + wait.
-        autopilot           → only branch if the tool returned
-                              `branch_to_alternative` AND the
-                              alternative does not change the
-                              primary reporting standard.
+        confirm first (manual / supervised) → present + wait.
 
       Hard rule: never propose more than ONE alternative per step.
       Two-alternative comparisons happen via repeated calls AFTER

--- a/src/research_os/protocols/notebook/notebook_workflow.yaml
+++ b/src/research_os/protocols/notebook/notebook_workflow.yaml
@@ -1,7 +1,7 @@
 id: notebook_workflow
 tier: 'execute'
 name: Notebook Workflow (the cell as the unit of work)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -73,10 +73,9 @@ steps:
 
       AUTONOMY GATE:
         Risk: reversible + cheap — scoping the notebook writes no cells yet.
-        adaptive (default) → state the scope and proceed.
-        manual / supervised → present the scope + planned notebook;
+        proceed (adaptive default, autopilot) → state the scope and proceed.
+        confirm first (manual / supervised) → present the scope + planned notebook;
           confirm before building it.
-        autopilot → state the scope and proceed.
 
   - id: structure_cells
     name: Structure the notebook so cells are the provenance unit
@@ -152,11 +151,9 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — logging the finding and moving on commits
         nothing that can't be revisited.
-        adaptive (default) → log the finding; proceed to the next notebook
+        proceed (adaptive default, autopilot) → log the finding; proceed to the next notebook
           or to synthesis per the researcher's stated output goal.
-        manual / supervised → present the finding + options; wait.
-        autopilot → log the finding; proceed to the next notebook or to
-          synthesis per the researcher's stated output goal.
+        confirm first (manual / supervised) → present the finding + options; wait.
 
 expected_outputs:
   - notebooks/*.ipynb  (top-to-bottom-runnable)

--- a/src/research_os/protocols/program/program_setup.yaml
+++ b/src/research_os/protocols/program/program_setup.yaml
@@ -1,7 +1,7 @@
 id: program_setup
 tier: 'plan'
 name: Program Setup (shared codebook, prereg, how studies roll up)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -141,13 +141,11 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — scaffolding the commons + first study writes
         structure, not findings; everything is re-editable.
-        adaptive (default) → write the commons, scaffold the first study,
+        proceed (adaptive default, autopilot) → write the commons, scaffold the first study,
           and enter its analysis loop; log each decision for later review.
-        manual / supervised → present the commons (codebook outline +
+        confirm first (manual / supervised) → present the commons (codebook outline +
           prereg + roll-up plan) + the proposed first study; wait for the
           researcher before scaffolding studies.
-        autopilot → write the commons, scaffold the first study, and
-          enter its analysis loop; log each decision for later review.
 
 expected_outputs:
   - shared/codebook.md

--- a/src/research_os/protocols/synthesis/synthesis_from_inputs.yaml
+++ b/src/research_os/protocols/synthesis/synthesis_from_inputs.yaml
@@ -1,7 +1,7 @@
 id: synthesis_from_inputs
 tier: 'synthesize'
 name: Synthesis — From Inputs (no workspace analysis required)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -114,11 +114,9 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — picking the output type shapes the draft, which
         stays editable.
-        adaptive (default) → pick based on `research_goal.output_types`
+        proceed (adaptive default, autopilot) → pick based on `research_goal.output_types`
                               when set; otherwise default to `report`.
-        manual / supervised → wait for the researcher to pick.
-        autopilot           → pick based on `research_goal.output_types`
-                              when set; otherwise default to `report`.
+        confirm first (manual / supervised) → wait for the researcher to pick.
 
   - id: create_shadow_step
     name: Create a shadow workspace step

--- a/src/research_os/protocols/synthesis/synthesis_title_workshop.yaml
+++ b/src/research_os/protocols/synthesis/synthesis_title_workshop.yaml
@@ -1,7 +1,7 @@
 id: synthesis_title_workshop
 tier: 'synthesize'
 name: Synthesis — Title Workshop (the single most-read sentence)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]
@@ -199,11 +199,9 @@ steps:
 
       AUTONOMY GATE:
         Risk: reversible — a title is trivially changed later.
-        adaptive (default) → pick the recommended option; tell the
+        proceed (adaptive default, autopilot) → pick the recommended option; tell the
                               researcher in one line.
-        manual / supervised → wait for the researcher to pick.
-        autopilot           → pick the recommended option; tell
-                              the researcher in one line.
+        confirm first (manual / supervised) → wait for the researcher to pick.
 
   - id: stress_test_the_winner
     name: Stress-test the winning title

--- a/src/research_os/protocols/visualization/visualization_workflow.yaml
+++ b/src/research_os/protocols/visualization/visualization_workflow.yaml
@@ -1,7 +1,7 @@
 id: visualization_workflow
 tier: 'synthesize'
 name: Visualization Workflow (figures on demand, no full analysis)
-version: '3.5.0'
+version: '3.8.0'
 schema_version: '2.0'
 last_reviewed: '2026-06-16'
 scope_tags:
@@ -73,11 +73,9 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — inferring a figure's shape/destination produces
         a plan, not a committed figure.
-        adaptive (default) → infer + proceed; tell the researcher the
+        proceed (adaptive default, autopilot) → infer + proceed; tell the researcher the
                               inferred shape in one line.
-        manual / supervised → ask before assuming a shape or destination.
-        autopilot           → infer + proceed; tell the researcher the
-                              inferred shape in one line.
+        confirm first (manual / supervised) → ask before assuming a shape or destination.
 
   - id: locate_sources
     name: Locate the data the figure(s) will draw from
@@ -276,11 +274,9 @@ steps:
       AUTONOMY GATE:
         Risk: reversible — curating vs showing-all is a presentation choice
         on a plan, fully changeable.
-        adaptive (default) → curate by default; surface the choice as a
+        proceed (adaptive default, autopilot) → curate by default; surface the choice as a
                               one-line suggestion.
-        manual / supervised → wait for the researcher to choose.
-        autopilot           → curate by default; surface the choice as
-                              a one-line suggestion.
+        confirm first (manual / supervised) → wait for the researcher to choose.
 
 expected_outputs:
   - workspace/scratch/figure_plan.md   (or active step's scratch/)

--- a/tests/unit/test_gate_idiom_collapsed.py
+++ b/tests/unit/test_gate_idiom_collapsed.py
@@ -1,0 +1,114 @@
+"""v3.8.0: AUTONOMY GATE blocks use the collapsed proceed/confirm idiom.
+
+Before this slice every AUTONOMY GATE block in the protocol catalogue spelled
+out four autonomy modes in full — `adaptive (default) → ...`, `manual /
+supervised → ...`, `autopilot → ...` — restating the same proceed-path twice
+(adaptive + autopilot almost always said the same thing). That made the
+adaptive default visually co-equal with three override modes and bloated every
+gate by ~40%.
+
+v3.8.0 collapses each block to two behaviour lines that make adaptive primary:
+
+    AUTONOMY GATE:
+      Risk: <dimension> — <why>.
+      proceed (adaptive default, autopilot) → <proceed behaviour>.
+      confirm first (manual / supervised) → <confirm behaviour>.
+
+Autopilot nuance (the rare case where autopilot bypassed a confirm-floor that
+adaptive honours) is preserved inline as a parenthetical "(Under autopilot,
+...)" clause rather than a separate mode line.
+
+These tests lock the new idiom catalogue-wide so a future edit can't silently
+regress a gate back to the verbose four-mode form.
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+_PROTOCOLS = _REPO / "src" / "research_os" / "protocols"
+
+# The one sanctioned exception: analysis_plan.yaml carries a bulleted
+# `AUTONOMY GATE (read interaction.autonomy_level):` variant that lists modes
+# as markdown bullets inside a longer reasoning passage. It is intentionally
+# not part of the collapsed two-line idiom.
+_BULLET_VARIANT_MARKER = "AUTONOMY GATE (read interaction.autonomy_level)"
+
+
+def _yaml_files() -> list[str]:
+    return sorted(glob.glob(str(_PROTOCOLS / "**" / "*.yaml"), recursive=True))
+
+
+def _collapsed_blocks() -> list[tuple[str, int]]:
+    """Return (file, line) for every collapsed `proceed (adaptive default`
+    gate line across the catalogue."""
+    out: list[tuple[str, int]] = []
+    for f in _yaml_files():
+        for i, line in enumerate(Path(f).read_text().splitlines(), start=1):
+            if "proceed (adaptive default" in line:
+                out.append((f, i))
+    return out
+
+
+def test_catalogue_uses_collapsed_proceed_idiom():
+    """Every standard AUTONOMY GATE block now leads with the collapsed
+    `proceed (adaptive default, autopilot) →` line."""
+    blocks = _collapsed_blocks()
+    # There are 28 well-formed gate blocks in the catalogue (the count grows
+    # as protocols are added — assert a floor, not an exact number, so adding
+    # a new gated protocol doesn't fail this test).
+    assert len(blocks) >= 28, (
+        f"expected >=28 collapsed gate blocks, found {len(blocks)}"
+    )
+
+
+def test_no_verbose_four_mode_gate_lines_remain():
+    """The old verbose form (`adaptive (default) →` as a standalone gate line)
+    must not survive anywhere except the sanctioned bulleted variant."""
+    offenders: list[str] = []
+    for f in _yaml_files():
+        text = Path(f).read_text()
+        has_bullet_variant = _BULLET_VARIANT_MARKER in text
+        for i, line in enumerate(text.splitlines(), start=1):
+            if re.search(r"adaptive \(default\)\s*→", line):
+                # The bulleted variant legitimately keeps `- adaptive (default) →`.
+                if has_bullet_variant and line.lstrip().startswith("- adaptive"):
+                    continue
+                offenders.append(f"{Path(f).name}:{i}: {line.strip()}")
+    assert not offenders, (
+        "verbose four-mode gate lines must be collapsed:\n" + "\n".join(offenders)
+    )
+
+
+def test_collapsed_blocks_pair_proceed_with_confirm():
+    """Each collapsed `proceed (...)` line is followed (within a few lines) by
+    a matching `confirm first (manual / supervised) →` line, so no gate loses
+    its override path."""
+    for f, ln in _collapsed_blocks():
+        lines = Path(f).read_text().splitlines()
+        window = "\n".join(lines[ln - 1 : ln + 8])
+        assert "confirm first (manual / supervised)" in window, (
+            f"{Path(f).name}:{ln} proceed-line has no matching confirm-first line"
+        )
+
+
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "build/spec_and_design.yaml",
+        "build/test_strategy.yaml",
+        "build/release_and_changelog.yaml",
+    ],
+)
+def test_autopilot_nuance_preserved(rel):
+    """The three blocks where autopilot deviated from adaptive keep that nuance
+    inline as a parenthetical clause — collapsing must not drop a floor."""
+    text = (_PROTOCOLS / rel).read_text()
+    assert "Under autopilot" in text, (
+        f"{rel}: autopilot-specific nuance was dropped during gate collapse"
+    )


### PR DESCRIPTION
Collapses all 28 AUTONOMY GATE blocks from the verbose 4-mode form to a 2-line proceed/confirm idiom that makes adaptive primary (autopilot nuance preserved inline). Links the 2 orphaned guidance protocols. New test locks the idiom. No behaviour change — MINOR. See CHANGELOG [3.8.0].