### PR TITLE
Release v3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.9.0] — canonical project layout (2026-06-22)
+
+A MINOR release that makes the project directory layout a single source of
+truth and documents it in one place. Fully backward-compatible — the
+folders an existing project gets at `init` are byte-identical to before.
+
+### Added
+- **`docs/PROJECT_LAYOUT.md`** — the canonical reference for the project
+  directory layout: the mode-agnostic safety backbone (`.os_state`,
+  `inputs/`, `workspace/`, `environment`, …) plus what each workspace mode
+  adds on top. Wired into the docs index. This is the single doc to read
+  for "what lives where."
+- **`LAYOUT_SPEC`** + **`describe_layout(mode)`** in `project_ops` — a
+  declarative layout definition and a render helper, so docs / `sys_boot` /
+  the wizard can describe the directory contract without re-listing folder
+  names inline.
+
+### Improved
+- The per-mode directory layout was hand-duplicated across six profiles —
+  every mode restated the same ~7 safety dirs, so the contract was
+  *implicit* and could silently drift. It is now **declared once** in
+  `LAYOUT_SPEC` and composed (`_compose_layout`); `SCAFFOLD_PROFILES` and
+  the back-compat constants (`TOP_LEVEL_DIRS` / `EAGER_DIRS` / `LAZY_DIRS`)
+  derive from it. ~190 lines of duplicated tuples removed; the safety
+  backbone can no longer drift between modes.
+
+### Fixed
+- (none)
+
+### Bumped
+- Version → 3.9.0.
+
+---
+
 ## [3.8.0] — adaptive-primary autonomy gates (2026-06-22)
 
 A MINOR release that makes the **adaptive** autonomy mode visibly primary

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.8.0
+version: 3.9.0
 date-released: 2026-06-22
 keywords:
   - research-data-management

--- a/docs/PROJECT_LAYOUT.md
+++ b/docs/PROJECT_LAYOUT.md
@@ -1,0 +1,159 @@
+# Project layout
+
+This is the canonical reference for the directory layout Research-OS
+builds inside your project. It is the **single source of truth** for what
+lives where — the wizard, `sys_boot`, and the in-project READMEs all derive
+from the same definition (`LAYOUT_SPEC` in `research_os/project_ops.py`), so
+this document and the folders on disk can't drift apart.
+
+If you only read one section, read [The safety backbone](#the-safety-backbone):
+those folders mean the same thing in every project, regardless of mode.
+
+---
+
+## The safety backbone
+
+Every project — whatever its workspace mode — is built on the same
+mode-agnostic backbone. These directories carry the same contract
+everywhere:
+
+| Directory | What it's for | Who writes it |
+|---|---|---|
+| `.os_state/` | Provenance + state (the audit ledger, step graph, config). The **only hard-locked tree**. | Research-OS only — never edit by hand. |
+| `docs/` | Project overview + glossary. | You + the AI. |
+| `inputs/` | Your source-of-truth drops. See below. | You (drops); AI may annotate. |
+| `inputs/raw_data/` | The raw data you bring to the project. **Soft-guarded** — overwrites are flagged. | You. |
+| `inputs/literature/` | The formal sources you bring (PDFs, papers). **Soft-guarded**. | You. |
+| `inputs/context/` | Free-form context: methodology notes, meeting takeaways, "if a new analyst opened this folder today, what would they need to know." AI-writable. | You + the AI. |
+| `workspace/` | The work surface — where the actual analysis / build happens. | The AI (governed by gates). |
+| `workspace/logs/` | The audit + override trail. | Research-OS. |
+| `workspace/scratch/` | The AI sandbox: throwaway probes, scratch code, intermediate junk. No gates here. | The AI, freely. |
+| `environment/` | Reproducibility: environment exports, lockfiles, the "how to re-run this" record. | The AI. |
+
+Two rules worth internalising:
+
+* **`inputs/` is yours, `workspace/` is the AI's.** You stage source
+  material in `inputs/`; the AI does its work in `workspace/` and writes
+  conclusions to `synthesis/`. `inputs/raw_data` and `inputs/literature`
+  are soft-guarded so the AI can't silently clobber what you dropped.
+* **`.os_state/` is off-limits.** It is the provenance ledger. Editing it
+  by hand breaks the audit guarantees that make the project trustworthy.
+
+---
+
+## Eager vs lazy
+
+Folders are created in one of two ways:
+
+* **Eager** — created at `research-os init`, always present, each seeded
+  with a tiny README so an empty folder is never a dead end.
+* **Lazy** — created only when the first artefact actually lands in them
+  (tools call `ensure_lazy_dir` first). This keeps a fresh project from
+  showing empty folders for work that hasn't started yet — e.g.
+  `synthesis/` doesn't appear until there's something to synthesise.
+
+---
+
+## Workspace modes
+
+The backbone is constant; the **work surface** between `inputs/` and the
+final write-up is shaped by your project's *workspace mode*. You pick the
+mode at init (or let the wizard infer it). Each mode only adds a small set
+of mode-specific folders — nothing about the safety backbone changes.
+
+### `analysis` (default)
+
+The classic linear, numbered-step model. Work proceeds as
+`workspace/01_*`, `workspace/02_*`, … and the paper lands in `synthesis/`.
+`literature/` at the top level is the project-wide corpus of record
+(aggregated from every step, distinct from your `inputs/literature/` drops).
+
+* **Adds:** `literature/`, `synthesis/` (lazy)
+
+### `tool_build`
+
+Research-OS sits *above* your tool as a governance layer. The tool itself
+lives in an **inner project directory** that gets its own `git init`; the
+outer Research-OS project tracks *why* and *whether it's done*:
+
+* `spec/` — what you're building + the design.
+* `decisions/` — Architecture Decision Records (ADRs).
+* `eval/` — the benchmark / eval harness that defines "done".
+
+* **Adds:** `spec/`, `decisions/`, `eval/`
+* **No `synthesis/`** — the deliverable is the tool, not a paper.
+
+### `exploration`
+
+Scratch-first. `workspace/scratch/` is your home base; gates are light.
+The numbered-step + log surface materialises only once a probe earns
+promotion to a real step.
+
+* **Adds:** nothing up front.
+* **Lazy:** `workspace/logs/`, `synthesis/` (appear on promote).
+
+### `notebook`
+
+Jupyter-first. The unit of work is a notebook, not a numbered step.
+
+* `notebooks/` — your notebooks (the unit of work).
+* `data/` — inputs the notebooks read.
+* `outputs/` — what they emit (figures, tables, exports).
+
+* **Adds:** `notebooks/`, `data/`, `outputs/`
+
+### `multi_study`
+
+A program / portfolio layout for work that spans several sub-studies.
+
+* `studies/` — each sub-study (itself a small project surface).
+* `shared/` — the program-wide commons: codebook, preregistration, the
+  governing protocol every study inherits.
+* `roll_up/` — cross-study synthesis + meta-analysis.
+
+* **Adds:** `studies/`, `shared/`, `roll_up/`
+
+### `hybrid` (research + software)
+
+Reuses the `analysis` layout. Any software lives in its own inner repo /
+package, auto-detected by Research-OS (`detect_software_components`) and
+surfaced in the workflow DAG + `sys_boot` rather than scaffolded as a
+fixed folder.
+
+* **Adds:** `literature/`, `synthesis/` (lazy) — same as `analysis`.
+
+---
+
+## Mode reference table
+
+What each mode creates at init (eager) versus on first use (lazy). The
+backbone (`.os_state`, `docs`, `inputs/*`, `workspace`, `workspace/logs`,
+`workspace/scratch`, `environment`) is present in every mode.
+
+| Mode | Mode-specific dirs | `synthesis/` | Lazy |
+|---|---|---|---|
+| `analysis` | `literature/` | yes (lazy) | `synthesis` |
+| `tool_build` | `spec/` `decisions/` `eval/` | no | (none) |
+| `exploration` | (none up front) | yes (lazy) | `workspace/logs`, `synthesis` |
+| `notebook` | `notebooks/` `data/` `outputs/` | yes (lazy) | `synthesis` |
+| `multi_study` | `studies/` `shared/` `roll_up/` | yes (lazy) | `synthesis` |
+| `hybrid` | `literature/` | yes (lazy) | `synthesis` |
+
+---
+
+## For maintainers
+
+This document is generated from one definition. To change the layout:
+
+1. Edit `LAYOUT_SPEC` in `src/research_os/project_ops.py` — declare only
+   the mode's `work` surface, whether it has `synthesis`, and its `lazy`
+   set. The composer (`_compose_layout`) builds the three directory tuples
+   (`top_level_dirs` / `eager_dirs` / `lazy_dirs`) deterministically.
+2. `SCAFFOLD_PROFILES` and the back-compat constants (`TOP_LEVEL_DIRS`
+   etc.) derive automatically, so the safety backbone can never drift
+   between modes.
+3. Update this doc's mode table to match. `describe_layout(mode)` renders
+   the per-mode eager/lazy breakdown if you want to confirm.
+
+Never re-list directory names inline elsewhere in the codebase or docs —
+read `LAYOUT_SPEC` / `SCAFFOLD_PROFILES` / `describe_layout()` instead.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Start at [**START.md**](START.md) — install, first project, cheatsheet (~15 mi
 Supporting:
 
 - [GLOSSARY.md](GLOSSARY.md) — the vocabulary: step, path, PATH container, plan.md, conclusions.md, the data folders, the literature corpus, audit.md, and more.
+- [PROJECT_LAYOUT.md](PROJECT_LAYOUT.md) — the canonical directory layout: the safety backbone (`.os_state`, `inputs/`, `workspace/`, …) and what each workspace mode adds. The single source of truth for what lives where.
 - [USE_CASES.md](USE_CASES.md) — "I want to write a paper / build a poster / reproduce a result" → which protocol fires.
 - [TOOL_BUILDER.md](TOOL_BUILDER.md) — building software, not analysing data? The **tool_build** workspace mode: spec → implement → test → ship.
 - [SETUP.md](SETUP.md) — per-IDE MCP wiring, troubleshooting installs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.8.0"
+version = "3.9.0"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.8.0"
+__version__ = "3.9.0"

--- a/src/research_os/project_ops.py
+++ b/src/research_os/project_ops.py
@@ -166,269 +166,176 @@ def resolve_step_dir(workspace: Path, step_id: str) -> Path | None:
 # summarise whatever was deposited so the dashboard's per-step appendix can
 # surface it.
 
-TOP_LEVEL_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "literature",        # project-wide corpus of record (aggregated from every step)
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "synthesis",
-    "environment",
-)
-
-# Directories created EAGERLY (always populated, never empty after init).
-# inputs/{raw_data,literature,context} are eager because GETTING_STARTED
-# tells the researcher to drop files there, and the dirs must exist for
-# that `cp` to work without `mkdir -p` friction. Each is seeded with a
-# tiny README explaining what belongs there so an empty folder isn't a
-# dead end.
-EAGER_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "literature",
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "environment",
-)
-
-# Directories created LAZILY (only when the first artefact lands in them).
-# Tools that write into them MUST call ``ensure_lazy_dir`` first.
-LAZY_DIRS = (
-    "synthesis",
-)
-
-
-# ---------------------------------------------------------------------------
-# Scaffold profiles — one per workspace.mode.
+# ===========================================================================
+# CANONICAL DIRECTORY LAYOUT — single source of truth
+# ===========================================================================
+# Every workspace.mode used to hand-duplicate three near-identical directory
+# tuples (top_level / eager / lazy), restating the ~7 mode-agnostic safety
+# dirs in each. That made the layout *implicit* — a change to the safety
+# contract meant editing a dozen copy-pasted tuples, and nothing guaranteed
+# the copies stayed in sync.
 #
-# A *profile* is the directory contract the scaffold builds for a given
-# kind of work. ``analysis`` reproduces today's behaviour BYTE-IDENTICALLY
-# (it literally reuses the module constants above); the others tailor the
-# surface to how that work actually flows.
+# The layout is now DECLARED ONCE here and COMPOSED. Each profile = a fixed
+# backbone (safety prefix + workspace tree + environment) plus a small,
+# mode-specific *work surface*. The composer (`_compose_layout`) builds the
+# three tuples deterministically; `SCAFFOLD_PROFILES` is derived from
+# `LAYOUT_SPEC`, so the safety contract can never drift between modes.
 #
-# Mode-agnostic safety invariants stay constant across every profile:
-# ``.os_state`` (the only hard-locked tree), ``inputs/`` (source-of-truth;
-# the original ``raw_data/`` + ``literature/`` drops are soft-guarded,
-# ``context/`` + ``researcher_config.yaml`` are AI-writable),
-# ``docs`` (overview/glossary), ``environment`` (reproducibility),
-# and ``workspace/scratch`` (the AI sandbox). Profiles only choose how the
-# *work surface* between inputs and outputs is shaped.
+# Anything that needs the canonical layout — the wizard, sys_boot, the
+# README templates, docs — should read `LAYOUT_SPEC` / `SCAFFOLD_PROFILES`
+# / `describe_layout()` rather than re-listing directory names inline.
 #
-#   analysis    → the classic linear numbered-step model. workspace/NN_* +
-#                 synthesis/. UNCHANGED.
-#   tool_build  → Research OS sits ABOVE as a governance layer: spec/ (what
-#                 we're building + design), decisions/ (ADRs), eval/ (the
-#                 benchmark / eval harness that defines "done"), plus
-#                 milestones.md / governance.md / CHANGELOG.md. The actual
-#                 tool lives in an INNER project dir that gets its own
-#                 git init (see scaffold_minimal_workspace).
-#   exploration → scratch-first. workspace/scratch is the home base; gates
-#                 are light; promote a probe to a numbered step when it
-#                 earns it. Everything heavyweight stays lazy.
+# The mode-agnostic safety backbone (constant across EVERY profile):
+#   • ``.os_state``        the only hard-locked tree (provenance / state)
+#   • ``docs``             overview + glossary
+#   • ``inputs/``          source-of-truth drops: raw_data/ + literature/ are
+#                          soft-guarded, context/ + researcher_config.yaml are
+#                          AI-writable
+#   • ``workspace/``       the work surface; ``workspace/logs`` (audit +
+#                          override trail) and ``workspace/scratch`` (the AI
+#                          sandbox) always live underneath
+#   • ``environment``      reproducibility (env exports, lockfiles)
+#
+# Profiles only choose the *work surface* between inputs and outputs, and
+# whether ``synthesis/`` exists (the eventual paper/report/dashboard home).
 # ---------------------------------------------------------------------------
 
-_TOOL_BUILD_TOP_LEVEL_DIRS = (
+# The fixed backbone, declared once.
+_SAFETY_PREFIX: tuple[str, ...] = (
     ".os_state",
     "docs",
     "inputs",
     "inputs/raw_data",
     "inputs/literature",
     "inputs/context",
-    "spec",
-    "decisions",
-    "eval",
+)
+_WORKSPACE_TREE: tuple[str, ...] = (
     "workspace",
     "workspace/logs",
     "workspace/scratch",
-    "environment",
 )
+_ENVIRONMENT: tuple[str, ...] = ("environment",)
 
-_TOOL_BUILD_EAGER_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "spec",
-    "decisions",
-    "eval",
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "environment",
-)
 
-_EXPLORATION_TOP_LEVEL_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "synthesis",
-    "environment",
-)
-
-# Exploration is deliberately minimal: scratch is the home base, the
-# numbered-step + log surface materialises only once a probe is promoted.
-_EXPLORATION_EAGER_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "workspace",
-    "workspace/scratch",
-    "environment",
-)
-
-_EXPLORATION_LAZY_DIRS = (
-    "workspace/logs",
-    "synthesis",
-)
-
-# ── notebook ────────────────────────────────────────────────────────────
-# A Jupyter-first layout: the unit of work is a notebook in ``notebooks/``,
-# not a numbered analysis step. ``data/`` holds inputs the notebooks read,
-# ``outputs/`` holds what they emit (figures / tables / exports). The
-# mode-agnostic safety dirs (.os_state, inputs/*, docs, environment,
-# workspace/scratch) hold as in every profile. workspace/logs stays eager
-# so audit/override trails have a home; synthesis is lazy (a notebook
-# project still writes a paper/report eventually, but not at cold init).
-_NOTEBOOK_TOP_LEVEL_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "notebooks",
-    "data",
-    "outputs",
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "synthesis",
-    "environment",
-)
-
-_NOTEBOOK_EAGER_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "notebooks",
-    "data",
-    "outputs",
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "environment",
-)
-
-_NOTEBOOK_LAZY_DIRS = (
-    "synthesis",
-)
-
-# ── multi_study (program) ───────────────────────────────────────────────
-# A portfolio / program layout. ``studies/`` holds each sub-study (every
-# child is itself a small project surface the researcher fills in). ``shared/``
-# is the program-wide commons: the codebook, the preregistration, the
-# governing protocol every study inherits. ``roll_up/`` is where cross-study
-# synthesis + meta-analysis live. The classic numbered-step ``workspace/``
-# surface stays minimal here — the unit of work is a STUDY, not a step;
-# heavyweight per-study analysis happens inside each ``studies/<child>/``.
-_MULTI_STUDY_TOP_LEVEL_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "studies",
-    "shared",
-    "roll_up",
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "synthesis",
-    "environment",
-)
-
-_MULTI_STUDY_EAGER_DIRS = (
-    ".os_state",
-    "docs",
-    "inputs",
-    "inputs/raw_data",
-    "inputs/literature",
-    "inputs/context",
-    "studies",
-    "shared",
-    "roll_up",
-    "workspace",
-    "workspace/logs",
-    "workspace/scratch",
-    "environment",
-)
-
-_MULTI_STUDY_LAZY_DIRS = (
-    "synthesis",
-)
-
-SCAFFOLD_PROFILES: dict[str, dict[str, tuple[str, ...]]] = {
-    # analysis == today's behaviour, byte-identical (reuses the constants).
+# Per-mode declarative spec. Each entry declares ONLY what differs from the
+# backbone:
+#   work     — the mode-specific work-surface dirs (inserted after the safety
+#              prefix, before the workspace tree)
+#   synthesis— whether ``synthesis/`` is part of the layout at all
+#   lazy     — dirs created LAZILY (only when the first artefact lands; tools
+#              must call ``ensure_lazy_dir`` first). Everything else is eager.
+#   summary  — one-line human description (surfaced by ``describe_layout``)
+LAYOUT_SPEC: dict[str, dict] = {
+    # analysis → the classic linear numbered-step model. workspace/NN_* +
+    # synthesis/. ``literature/`` is the project-wide corpus of record
+    # (aggregated from every step).
     "analysis": {
-        "top_level_dirs": TOP_LEVEL_DIRS,
-        "eager_dirs": EAGER_DIRS,
-        "lazy_dirs": LAZY_DIRS,
+        "work": ("literature",),
+        "synthesis": True,
+        "lazy": ("synthesis",),
+        "summary": "Linear numbered-step analysis; synthesis/ holds the paper.",
     },
+    # tool_build → Research OS sits ABOVE as a governance layer: spec/ (what
+    # we're building + design), decisions/ (ADRs), eval/ (the benchmark that
+    # defines "done"). The actual tool lives in an INNER project dir with its
+    # own git init (see scaffold_minimal_workspace). No synthesis/.
     "tool_build": {
-        "top_level_dirs": _TOOL_BUILD_TOP_LEVEL_DIRS,
-        "eager_dirs": _TOOL_BUILD_EAGER_DIRS,
-        "lazy_dirs": (),
+        "work": ("spec", "decisions", "eval"),
+        "synthesis": False,
+        "lazy": (),
+        "summary": "Governance layer over an inner tool repo: spec/decisions/eval.",
     },
+    # exploration → scratch-first. workspace/scratch is the home base; the
+    # numbered-step + log surface materialises only once a probe is promoted,
+    # so workspace/logs and synthesis stay lazy.
     "exploration": {
-        "top_level_dirs": _EXPLORATION_TOP_LEVEL_DIRS,
-        "eager_dirs": _EXPLORATION_EAGER_DIRS,
-        "lazy_dirs": _EXPLORATION_LAZY_DIRS,
+        "work": (),
+        "synthesis": True,
+        "lazy": ("workspace/logs", "synthesis"),
+        "summary": "Scratch-first probing; numbered steps appear on promote.",
     },
+    # notebook → Jupyter-first. The unit of work is a notebook in notebooks/;
+    # data/ holds inputs the notebooks read, outputs/ holds what they emit.
     "notebook": {
-        "top_level_dirs": _NOTEBOOK_TOP_LEVEL_DIRS,
-        "eager_dirs": _NOTEBOOK_EAGER_DIRS,
-        "lazy_dirs": _NOTEBOOK_LAZY_DIRS,
+        "work": ("notebooks", "data", "outputs"),
+        "synthesis": True,
+        "lazy": ("synthesis",),
+        "summary": "Jupyter-first: notebooks/ + data/ + outputs/.",
     },
+    # multi_study → portfolio / program. studies/ holds each sub-study,
+    # shared/ is the program-wide commons (codebook, prereg, governing
+    # protocol), roll_up/ is where cross-study synthesis + meta-analysis live.
     "multi_study": {
-        "top_level_dirs": _MULTI_STUDY_TOP_LEVEL_DIRS,
-        "eager_dirs": _MULTI_STUDY_EAGER_DIRS,
-        "lazy_dirs": _MULTI_STUDY_LAZY_DIRS,
+        "work": ("studies", "shared", "roll_up"),
+        "synthesis": True,
+        "lazy": ("synthesis",),
+        "summary": "Program/portfolio: studies/ + shared/ + roll_up/.",
     },
-    # hybrid (research + software) reuses the analysis layout — the
-    # software lives in its own inner repo / package, detected by
-    # detect_software_components() and surfaced in the workflow DAG +
-    # sys_boot rather than scaffolded as a fixed folder.
+    # hybrid (research + software) reuses the analysis layout — the software
+    # lives in its own inner repo / package, detected by
+    # detect_software_components() and surfaced in the workflow DAG + sys_boot
+    # rather than scaffolded as a fixed folder.
     "hybrid": {
-        "top_level_dirs": TOP_LEVEL_DIRS,
-        "eager_dirs": EAGER_DIRS,
-        "lazy_dirs": LAZY_DIRS,
+        "work": ("literature",),
+        "synthesis": True,
+        "lazy": ("synthesis",),
+        "summary": "Analysis layout + inner software repo (auto-detected).",
     },
 }
+
+
+def _compose_layout(spec: dict) -> dict[str, tuple[str, ...]]:
+    """Build the three directory tuples for one mode from its declarative spec.
+
+    top_level = safety prefix + work surface + workspace tree + [synthesis]
+                + environment
+    eager     = top_level minus the lazy dirs
+    lazy      = the deferred dirs (created on first artefact)
+    """
+    lazy = tuple(spec.get("lazy", ()))
+    top: tuple[str, ...] = (
+        _SAFETY_PREFIX
+        + tuple(spec.get("work", ()))
+        + _WORKSPACE_TREE
+        + (("synthesis",) if spec.get("synthesis") else ())
+        + _ENVIRONMENT
+    )
+    eager = tuple(d for d in top if d not in lazy)
+    return {"top_level_dirs": top, "eager_dirs": eager, "lazy_dirs": lazy}
+
+
+# Derived registry — one composed profile per mode. Keep the same public
+# name + shape downstream code already imports.
+SCAFFOLD_PROFILES: dict[str, dict[str, tuple[str, ...]]] = {
+    mode: _compose_layout(spec) for mode, spec in LAYOUT_SPEC.items()
+}
+
+# Back-compat module constants: ``analysis`` is the default profile, so the
+# historical ``TOP_LEVEL_DIRS`` / ``EAGER_DIRS`` / ``LAZY_DIRS`` names now
+# alias the composed analysis layout (byte-identical to the old hand-written
+# tuples). Existing imports keep working.
+TOP_LEVEL_DIRS: tuple[str, ...] = SCAFFOLD_PROFILES["analysis"]["top_level_dirs"]
+EAGER_DIRS: tuple[str, ...] = SCAFFOLD_PROFILES["analysis"]["eager_dirs"]
+LAZY_DIRS: tuple[str, ...] = SCAFFOLD_PROFILES["analysis"]["lazy_dirs"]
+
+
+def describe_layout(mode: str = "analysis") -> str:
+    """Human-readable one-paragraph description of a mode's canonical layout.
+
+    Single source for docs / sys_boot / the wizard to render the directory
+    contract without re-listing folder names inline.
+    """
+    spec = LAYOUT_SPEC.get(mode)
+    if spec is None:
+        raise KeyError(f"unknown workspace mode: {mode!r}")
+    profile = SCAFFOLD_PROFILES[mode]
+    eager = ", ".join(profile["eager_dirs"])
+    lazy = ", ".join(profile["lazy_dirs"]) or "(none)"
+    return (
+        f"{mode}: {spec['summary']}\n"
+        f"  created at init (eager): {eager}\n"
+        f"  created on first use (lazy): {lazy}"
+    )
 
 # Files whose presence in a directory marks it as a software component.
 _SOFTWARE_MARKERS = {

--- a/tests/unit/test_workspace_modes.py
+++ b/tests/unit/test_workspace_modes.py
@@ -426,3 +426,76 @@ def test_mode_to_shape_derives_from_registry():
     expected = {m: e.shape for m, e in MODE_ROUTING.items() if e.shape}
     assert _MODE_TO_SHAPE == expected
 
+
+# ── canonical directory layout (single source of truth) ───────────
+# The layout is now declared once in LAYOUT_SPEC and composed; SCAFFOLD_PROFILES
+# is derived. These lock the canonical contract so a future edit can't silently
+# break the safety backbone or let a profile drift out of the spec.
+
+# The mode-agnostic safety backbone that MUST appear in every profile.
+_BACKBONE = (
+    ".os_state",
+    "docs",
+    "inputs",
+    "inputs/raw_data",
+    "inputs/literature",
+    "inputs/context",
+    "workspace",
+    "workspace/logs",
+    "workspace/scratch",
+    "environment",
+)
+
+
+def test_scaffold_profiles_is_derived_from_layout_spec():
+    """SCAFFOLD_PROFILES must be the composition of LAYOUT_SPEC — no hand-
+    written tuple may sneak back in and drift from the declarative source."""
+    from research_os.project_ops import (
+        LAYOUT_SPEC,
+        SCAFFOLD_PROFILES,
+        _compose_layout,
+    )
+    assert set(SCAFFOLD_PROFILES) == set(LAYOUT_SPEC)
+    for mode, spec in LAYOUT_SPEC.items():
+        assert SCAFFOLD_PROFILES[mode] == _compose_layout(spec)
+
+
+def test_safety_backbone_present_in_every_mode():
+    """Every workspace mode carries the full safety backbone in its
+    top_level_dirs — the contract that .os_state/inputs/workspace/environment
+    mean the same thing everywhere."""
+    for mode, prof in SCAFFOLD_PROFILES.items():
+        top = prof["top_level_dirs"]
+        for d in _BACKBONE:
+            assert d in top, f"{mode} missing backbone dir {d!r}"
+
+
+def test_eager_plus_lazy_partition_top_level():
+    """eager_dirs and lazy_dirs partition top_level_dirs exactly — nothing
+    created twice, nothing forgotten. Guards the composer's set logic."""
+    for mode, prof in SCAFFOLD_PROFILES.items():
+        top = set(prof["top_level_dirs"])
+        eager = set(prof["eager_dirs"])
+        lazy = set(prof["lazy_dirs"])
+        assert eager.isdisjoint(lazy), f"{mode}: dir is both eager and lazy"
+        assert eager | lazy == top, f"{mode}: eager+lazy != top_level"
+
+
+def test_describe_layout_covers_every_mode():
+    """describe_layout renders for every mode and names the mode + its
+    eager/lazy split — the single doc/sys_boot rendering path can't break
+    silently for a mode."""
+    from research_os.project_ops import LAYOUT_SPEC, describe_layout
+    for mode in LAYOUT_SPEC:
+        text = describe_layout(mode)
+        assert text.startswith(f"{mode}:")
+        assert "created at init (eager):" in text
+        assert "created on first use (lazy):" in text
+
+
+def test_describe_layout_rejects_unknown_mode():
+    from research_os.project_ops import describe_layout
+    import pytest
+    with pytest.raises(KeyError):
+        describe_layout("nope_not_a_mode")
+


### PR DESCRIPTION
Bumps version to v3.9.0. Canonical project layout (single source of truth) + docs/PROJECT_LAYOUT.md. See CHANGELOG.md.