### PR TITLE
Release v3.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,55 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.11.0] — step report adoption (2026-06-22)
+
+A MINOR release that makes the **step report** (added in 3.10.0)
+discoverable and frictionless. Fully backward-compatible — every new
+behaviour is additive guidance the AI may act on, never a hard step.
+
+### Added
+
+- **Deliverable chooser surfaces step reports.** `deliverable_chooser`
+  now returns an `interim_artifacts` list alongside the gated
+  final-deliverable recommendations. A step report is offered there
+  (never in `research_goal.output_types` — it isn't a scope commitment)
+  once at least one step has conclusions worth presenting. Pure read of
+  the existing on-disk counts; nothing forced.
+- **End-of-step nudge.** `finalize_path` now returns a
+  `step_report_nudge`. When a step has substantive conclusions AND at
+  least one figure, it suggests a step report with the exact
+  `tool_synthesis_scaffold(kind='step_report', step=…)` call and an
+  explicit "offer it, don't auto-build — ask first" instruction. Stays
+  silent when the step isn't presentation-ready.
+- **Figure staging.** Scaffolding a step report now stages that step's
+  figures into `synthesis/updates/figures/` (new `stage_step_figures`
+  helper), flags the focal figure, and reports the relative
+  `figures/…` paths so the page travels as one self-contained file with
+  no `workspace/` references. Steps with no figures are handled
+  gracefully — the report can still be authored.
+
+### Improved
+
+- **Updates index polish.** The auto-generated
+  `synthesis/updates/index.html` diary now shows a per-entry date (from
+  file mtime) and a one-line headline (the report's first paragraph,
+  truncated), so it reads as a real changelog rather than a bare link
+  list. Still navigation-only, still offline-safe, still derived purely
+  from disk.
+- **Protocol doctrine.** `docs/PROTOCOL_DOCTRINE.md` now cites
+  `synthesis_step_report` as the canonical **guidance-first** protocol
+  (no `required_structure`/archetype menu) contrasted against
+  `synthesis_dashboard`'s deliberate prescription — a reference example
+  for future protocol authors.
+
+### Bumped
+
+- Version → 3.11.0 across `pyproject.toml`, `__init__.py`,
+  `CITATION.cff`; `synthesis_step_report.yaml` protocol version → 3.11.0
+  (behaviour changed: figure staging + nudge + index).
+
+---
+
 ## [3.10.0] — step reports (2026-06-22)
 
 A MINOR release adding a new synthesis deliverable: the **step report** —

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.10.0
+version: 3.11.0
 date-released: 2026-06-22
 keywords:
   - research-data-management

--- a/docs/PROTOCOL_DOCTRINE.md
+++ b/docs/PROTOCOL_DOCTRINE.md
@@ -162,6 +162,36 @@ Scaffold:
     a positive justification, not a default.
 ```
 
+### A whole protocol as scaffold — `synthesis_step_report`
+
+The same principle scales from a single step to an entire deliverable
+protocol. The two synthesis protocols that produce visual artefacts sit
+at opposite ends on purpose:
+
+* **`synthesis_dashboard`** carries a `required_structure` and an
+  archetype menu. That's deliberate prescription (see *When prescription
+  IS the right answer*): a dashboard is a known genre with load-bearing
+  conventions — a filter bar, an evidence grid, drill-downs — and a
+  researcher reaching for one expects that shape.
+
+* **`synthesis_step_report`** is the canonical **guidance-first**
+  protocol. It has **no `required_structure`, no `forbidden_structure`,
+  no archetype menu**. It frames the work entirely through
+  `design_principles` (honesty, grounding, one-glance hierarchy,
+  travels-as-one-file) and `quality_standards` (a11y baseline, offline
+  safety, no placeholders, every number traceable to the step's
+  `conclusions.md`). The scaffold the tool writes is a *minimal shell* —
+  palette tokens, an accessibility baseline, offline safety, and the RO
+  house identity — with the design intent left in comments only. The AI
+  invents the layout and sections that tell THIS step's story fastest.
+
+The lesson: prescribe structure only when the genre's conventions are
+load-bearing. When the right shape depends on the specific findings —
+as it does for a per-step report — give the AI principles and a quality
+bar, then get out of its way. The gate (`_check_step_report`) enforces
+the *bar* (honesty, grounding, accessibility, offline, no placeholders),
+never a heading list.
+
 ## `next_protocol_kind` — how the AI should interpret `next_protocol`
 
 `next_protocol:` alone is ambiguous: does the AI **advance forward** to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.10.0"
+version = "3.11.0"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.10.0"
+__version__ = "3.11.0"

--- a/src/research_os/protocols/synthesis/synthesis_step_report.yaml
+++ b/src/research_os/protocols/synthesis/synthesis_step_report.yaml
@@ -1,7 +1,7 @@
 id: synthesis_step_report
 tier: 'synthesize'
 name: Synthesis — Step Report (one step, meeting-grade visual artefact)
-version: '3.10.0'
+version: '3.11.0'
 schema_version: '2.0'
 scope_tags:
   domain: [any]

--- a/src/research_os/tools/actions/research/gradient.py
+++ b/src/research_os/tools/actions/research/gradient.py
@@ -17,7 +17,11 @@ Two public functions back the gradient MCP tools:
   recommends which deliverable(s) to build with rationale. CRUCIALLY it
   respects output_types gating: it never pushes a deliverable the
   researcher didn't opt into, and when output_types is empty it ASKS
-  rather than assuming a paper.
+  rather than assuming a paper. Alongside the gated final-deliverable
+  recommendations it also surfaces ``interim_artifacts`` — chiefly the
+  step report — which are NOT output_types-gated because they're cheap,
+  reversible, per-step artefacts, not a scope commitment. These are
+  offered (never auto-built) once a step has conclusions worth showing.
 
 Both are read-mostly. ``explain_scaffold`` has no side effects.
 ``deliverable_chooser`` only reads state + config (no writes), so it is
@@ -215,6 +219,40 @@ _DELIVERABLE_BLURB: dict[str, str] = {
     "handout": "A printable one/two-page handout.",
 }
 
+# Step reports are NOT a declared final deliverable (they never belong in
+# research_goal.output_types). They're an interim, per-step artefact: a
+# self-contained presentation-grade page about ONE analysis step, for a
+# meeting screen-share or a milestone email. Cheap + reversible, so the
+# chooser may always SURFACE it as available without it being scope creep —
+# but it never auto-builds one or pushes it as "the" next deliverable.
+_INTERIM_STEP_REPORT: dict[str, str] = {
+    "kind": "step_report",
+    "what_it_is": (
+        "A self-contained visual page about ONE analysis step — the kind "
+        "you screen-share in a meeting or attach to a milestone email."
+    ),
+    "protocol": "synthesis/synthesis_step_report",
+    "scope": "interim",
+}
+
+
+def _interim_artifacts(counts: dict[str, int]) -> list[dict[str, Any]]:
+    """Interim artefacts the chooser may always offer (not output_types-gated).
+
+    Returns the step-report option only once at least one step has
+    conclusions worth presenting — otherwise there's nothing to report on
+    yet. Pure read of the already-computed counts; never raises.
+    """
+    if counts.get("steps_with_conclusions", 0) < 1:
+        return []
+    entry = dict(_INTERIM_STEP_REPORT)
+    entry["rationale"] = (
+        "Optional + interim: not a final deliverable and not in "
+        "output_types. Offer it when a step's results are worth showing "
+        "(meeting, milestone email). Never auto-build — ask first."
+    )
+    return [entry]
+
 
 def _count_artifacts(root: Path) -> dict[str, int]:
     """Tally what's actually on disk — steps w/ conclusions, figures, citations.
@@ -357,6 +395,7 @@ def deliverable_chooser(root: Path) -> dict[str, Any]:
             "artifact_counts": counts,
             "declared_output_types": [],
             "options": options,
+            "interim_artifacts": _interim_artifacts(counts),
             "ask_user": (
                 "No deliverable is declared in researcher_config.yaml "
                 "(research_goal.output_types is empty). What would you like "
@@ -418,6 +457,7 @@ def deliverable_chooser(root: Path) -> dict[str, Any]:
         "artifact_counts": counts,
         "declared_output_types": declared,
         "recommendations": recommendations,
+        "interim_artifacts": _interim_artifacts(counts),
         "pending_count": len(pending),
         "next_deliverable": (pending[0]["kind"] if pending else None),
         "scope_note": (

--- a/src/research_os/tools/actions/state/path.py
+++ b/src/research_os/tools/actions/state/path.py
@@ -931,6 +931,59 @@ def _figure_table_inventory(exp_dir: Path) -> dict[str, list[str]]:
     return out
 
 
+def _step_report_nudge(
+    path_name: str,
+    conc_path: Path,
+    n_figures: int,
+) -> dict[str, Any]:
+    """Suggest (never auto-build) a step report when a step is presentable.
+
+    A step report is worth offering once a step has substantive
+    conclusions AND at least one figure — i.e. there's a result with a
+    visual worth screen-sharing at a meeting or attaching to a milestone
+    email. This is a GUIDANCE nudge only: it returns the suggestion + the
+    exact tool call, and explicitly tells the AI to ASK first. It writes
+    nothing and decides nothing. ``suggested`` is False when the step
+    isn't presentation-ready yet, so the AI stays quiet.
+    """
+    try:
+        has_conclusions = bool(
+            conc_path.exists() and conc_path.stat().st_size > 80
+        )
+    except OSError:
+        has_conclusions = False
+    suggested = has_conclusions and n_figures >= 1
+    if not suggested:
+        return {
+            "suggested": False,
+            "reason": (
+                "Step not presentation-ready yet "
+                f"(conclusions={'yes' if has_conclusions else 'no'}, "
+                f"figures={n_figures}). No step report offered."
+            ),
+        }
+    return {
+        "suggested": True,
+        "reason": (
+            "This step has substantive conclusions and a figure — it's the "
+            "kind of result worth showing at a meeting or in a milestone "
+            "email."
+        ),
+        "what_it_is": (
+            "A self-contained, offline, presentation-grade HTML page about "
+            "THIS step alone — the AI designs the layout; nothing templated."
+        ),
+        "build_with": (
+            f"tool_synthesis_scaffold(kind='step_report', step='{path_name}')"
+        ),
+        "advice": (
+            "OFFER this, don't auto-build it. Ask the researcher whether "
+            "they want a shareable page for this step; only scaffold if "
+            "they say yes."
+        ),
+    }
+
+
 def finalize_path(
     path_name: str | None,
     root: Path,
@@ -1741,6 +1794,11 @@ def finalize_path(
             len(out_files) + len(inv["figures"]) + len(inv["tables"]) + len(inv["reports"])
         ),
         "plain_english_summary_present": bool(plain_summary_from_context),
+        "step_report_nudge": _step_report_nudge(
+            path_name=path_name,
+            conc_path=conc_path,
+            n_figures=len(inv["figures"]),
+        ),
     }
 
 

--- a/src/research_os/tools/actions/synthesis/scaffold.py
+++ b/src/research_os/tools/actions/synthesis/scaffold.py
@@ -907,6 +907,102 @@ def _step_report_slug(root: Path, step: str | None) -> str:
     return f"step-{clean}" if clean else "step-report"
 
 
+def stage_step_figures(root: Path, step: str | None) -> dict[str, Any]:
+    """Copy a step's figures into ``synthesis/updates/figures/`` so a step
+    report can reference them with portable relative ``figures/...`` paths.
+
+    A step report is meant to TRAVEL as a single self-contained file — so
+    its images must live next to it, not point back into ``workspace/``.
+    This helper resolves the step directory, copies every figure from its
+    ``outputs/figures/`` into ``synthesis/updates/figures/`` (skipping
+    unchanged files), and flags the focal figure (filename starting with
+    the step number, else alphabetically first) so the AI knows which one
+    leads. It NEVER edits the report HTML or invents a figure — it only
+    stages what the step actually produced. Returns ``status='empty'``
+    when the step has no figures (the report can still be authored).
+    """
+    import re
+    import shutil
+
+    figures_dir = root / "synthesis" / "updates" / "figures"
+    workspace = root / "workspace"
+    if not workspace.is_dir():
+        return {"status": "empty", "staged": [], "reason": "no workspace/"}
+
+    # Resolve the step directory (reuse the same matching as the slug helper).
+    step_dir: Path | None = None
+    if step:
+        num_match = re.search(r"(\d+)", str(step))
+        try:
+            from research_os.project_ops import discover_step_dirs
+
+            step_dirs = discover_step_dirs(workspace, include_dead=False)
+        except Exception:
+            step_dirs = []
+        if num_match:
+            target_num = int(num_match.group(1))
+            for d in step_dirs:
+                dm = re.match(r"(\d+)[_-](.+)", d.name)
+                if dm and int(dm.group(1)) == target_num:
+                    step_dir = d
+                    break
+        if step_dir is None:
+            # Exact directory name passed?
+            cand = workspace / str(step)
+            if cand.is_dir():
+                step_dir = cand
+    if step_dir is None:
+        return {
+            "status": "empty",
+            "staged": [],
+            "reason": f"no step directory resolved for step={step!r}",
+        }
+
+    src_figs = step_dir / "outputs" / "figures"
+    suffixes = {".png", ".jpg", ".jpeg", ".svg", ".gif", ".webp"}
+    candidates = (
+        [
+            f for f in sorted(src_figs.iterdir())
+            if f.is_file() and f.suffix.lower() in suffixes
+        ]
+        if src_figs.is_dir() else []
+    )
+    if not candidates:
+        return {
+            "status": "empty",
+            "staged": [],
+            "reason": f"{step_dir.name} has no figures in outputs/figures/",
+        }
+
+    step_num = step_dir.name.split("_", 1)[0]
+    focal = next(
+        (f for f in candidates if f.name.startswith(step_num + "_")),
+        candidates[0],
+    )
+
+    figures_dir.mkdir(parents=True, exist_ok=True)
+    staged: list[dict[str, Any]] = []
+    for f in candidates:
+        dest = figures_dir / f.name
+        try:
+            if not dest.exists() or dest.stat().st_mtime < f.stat().st_mtime:
+                shutil.copy2(f, dest)
+        except OSError:
+            continue
+        staged.append({
+            "filename": f.name,
+            "rel_path": f"figures/{f.name}",
+            "focal": (f == focal),
+        })
+    return {
+        "status": "success" if staged else "empty",
+        "staged": staged,
+        "focal": (f"figures/{focal.name}" if staged else None),
+        "figures_dir": str(figures_dir),
+        "source_step": step_dir.name,
+    }
+
+
 def rebuild_updates_index(root: Path) -> dict[str, Any]:
     """(Re)generate ``synthesis/updates/index.html`` — the project's visual
     diary landing page that lists every step report in chronological order.
@@ -923,6 +1019,7 @@ def rebuild_updates_index(root: Path) -> dict[str, Any]:
     """
     import html
     import re as _re
+    from datetime import date
 
     updates = root / "synthesis" / "updates"
     index_path = updates / "index.html"
@@ -930,7 +1027,8 @@ def rebuild_updates_index(root: Path) -> dict[str, Any]:
         return {"status": "empty", "count": 0}
 
     # Collect step reports — every .html under updates/ except the index.
-    reports: list[tuple[int, str, str, str]] = []  # (sort_key, slug, title, filename)
+    # Row tuple: (sort_key, slug, title, filename, headline, datestr)
+    reports: list[tuple[int, str, str, str, str, str]] = []
     for f in sorted(updates.glob("*.html")):
         if f.name == "index.html":
             continue
@@ -950,10 +1048,28 @@ def rebuild_updates_index(root: Path) -> dict[str, Any]:
             title = html.unescape(_re.sub(r"\s+", " ", title))
         else:
             title = f.stem
+        # Headline: first <p> AFTER the <h1> (the step's one-line takeaway).
+        # Skip the author-brief comment block — search only authored body.
+        headline = ""
+        after = txt[m.end():] if m else txt
+        pm = _re.search(r"<p[^>]*>(.*?)</p>", after, _re.I | _re.S)
+        if pm:
+            raw = _re.sub(r"<[^>]+>", "", pm.group(1))
+            raw = html.unescape(_re.sub(r"\s+", " ", raw)).strip()
+            if len(raw) > 160:
+                raw = raw[:157].rstrip() + "…"
+            headline = raw
+        # Date: file modification time, ISO yyyy-mm-dd (best-effort).
+        try:
+            datestr = date.fromtimestamp(f.stat().st_mtime).isoformat()
+        except OSError:
+            datestr = ""
         # Sort by leading step number when present, else push to the end.
         num_m = _re.search(r"step-(\d+)", f.stem)
         sort_key = int(num_m.group(1)) if num_m else 10**6
-        reports.append((sort_key, f.stem, title or f.stem, f.name))
+        reports.append(
+            (sort_key, f.stem, title or f.stem, f.name, headline, datestr)
+        )
 
     if not reports:
         # Nothing to index — drop a stale index so the folder stays honest.
@@ -962,9 +1078,24 @@ def rebuild_updates_index(root: Path) -> dict[str, Any]:
         return {"status": "empty", "count": 0}
 
     reports.sort(key=lambda r: (r[0], r[1]))
+
+    def _row(title: str, fn: str, headline: str, datestr: str) -> str:
+        date_html = (
+            f'<span class="date">{html.escape(datestr)}</span>' if datestr else ""
+        )
+        head_html = (
+            f'<span class="headline">{html.escape(headline)}</span>'
+            if headline else ""
+        )
+        return (
+            f'      <li><a href="{html.escape(fn)}">'
+            f'<span class="t">{html.escape(title)}</span>'
+            f"{date_html}{head_html}</a></li>"
+        )
+
     rows = "\n".join(
-        f'      <li><a href="{html.escape(fn)}">{html.escape(title)}</a></li>'
-        for _sk, _slug, title, fn in reports
+        _row(title, fn, headline, datestr)
+        for _sk, _slug, title, fn, headline, datestr in reports
     )
     doc = f"""<!DOCTYPE html>
 <html lang="en">
@@ -973,17 +1104,22 @@ def rebuild_updates_index(root: Path) -> dict[str, Any]:
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Step reports</title>
 <style>
-  :root {{ --ink: #1a1a1a; --paper: #FBF8F3; --rule: #d8d2c6; --accent: #3a5a40; }}
+  :root {{ --ink: #1a1a1a; --paper: #FBF8F3; --rule: #d8d2c6; --accent: #3a5a40; --muted: #5b5b5b; }}
   body {{ background: var(--paper); color: var(--ink); margin: 0;
          font: 16px/1.6 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }}
   main {{ max-width: 46rem; margin: 0 auto; padding: 3rem 1.5rem; }}
   h1 {{ font-weight: 600; letter-spacing: -0.01em; margin: 0 0 0.25rem; }}
-  p.sub {{ color: #5b5b5b; margin: 0 0 2rem; }}
+  p.sub {{ color: var(--muted); margin: 0 0 2rem; }}
   ul {{ list-style: none; padding: 0; margin: 0; }}
   li {{ border-bottom: 1px solid var(--rule); }}
   li a {{ display: block; padding: 0.85rem 0.25rem; color: var(--accent);
-          text-decoration: none; font-weight: 500; }}
+          text-decoration: none; }}
   li a:hover, li a:focus {{ text-decoration: underline; }}
+  .t {{ font-weight: 600; }}
+  .date {{ color: var(--muted); font-size: 0.82rem; font-weight: 400;
+           margin-left: 0.6rem; }}
+  .headline {{ display: block; color: var(--ink); font-weight: 400;
+               font-size: 0.92rem; margin-top: 0.15rem; }}
 </style>
 </head>
 <body data-archetype="updates-index">
@@ -1124,6 +1260,15 @@ def synthesis_scaffold(
         result["palette"] = palette
     if kind == "step_report":
         result["step"] = step
+        # Stage this step's figures next to the report so it travels as one
+        # self-contained file (relative figures/ paths, no workspace/ refs).
+        staged = stage_step_figures(root, step)
+        if staged.get("status") == "success":
+            result["staged_figures"] = staged.get("staged")
+            result["focal_figure"] = staged.get("focal")
+        else:
+            result["staged_figures"] = []
+            result["figures_note"] = staged.get("reason", "")
         # Refresh the diary landing page so synthesis/updates/index.html
         # always lists the full chain of step reports. Pure navigation —
         # derived from disk, no claims of its own.

--- a/tests/unit/test_step_report.py
+++ b/tests/unit/test_step_report.py
@@ -172,3 +172,127 @@ def test_index_empty_returns_empty(tmp_path: Path):
     assert out["status"] == "empty"
     assert out["count"] == 0
     assert not (tmp_path / "synthesis" / "updates" / "index.html").exists()
+
+
+# ---------------------------------------------------------------------------
+# v3.11.0 — step-report adoption: chooser, end-of-step nudge, index polish,
+# figure staging.
+# ---------------------------------------------------------------------------
+
+
+def test_interim_artifacts_gated_on_conclusions():
+    """deliverable_chooser surfaces step_report only once a step has results."""
+    from research_os.tools.actions.research.gradient import _interim_artifacts
+
+    assert _interim_artifacts({"steps_with_conclusions": 0}) == []
+    out = _interim_artifacts({"steps_with_conclusions": 1})
+    assert len(out) == 1
+    assert out[0]["kind"] == "step_report"
+    assert out[0]["scope"] == "interim"
+    assert out[0]["protocol"] == "synthesis/synthesis_step_report"
+    # Never framed as a final/declared deliverable.
+    assert "interim" in out[0]["rationale"].lower()
+
+
+def test_step_report_nudge_only_when_presentable(tmp_path):
+    """finalize_path's nudge fires only with conclusions AND a figure."""
+    from research_os.tools.actions.state.path import _step_report_nudge
+
+    conc = tmp_path / "conclusions.md"
+    # No conclusions yet.
+    assert _step_report_nudge("01_eda", conc, 0)["suggested"] is False
+    # Conclusions but no figure.
+    conc.write_text("# Findings\n" + "x" * 200, encoding="utf-8")
+    assert _step_report_nudge("01_eda", conc, 0)["suggested"] is False
+    # Conclusions + figure → suggested, with the exact tool call + ask-first.
+    out = _step_report_nudge("01_eda", conc, 2)
+    assert out["suggested"] is True
+    assert "tool_synthesis_scaffold(kind='step_report'" in out["build_with"]
+    assert "01_eda" in out["build_with"]
+    assert "ask" in out["advice"].lower() or "offer" in out["advice"].lower()
+
+
+def test_updates_index_has_headline_and_date(tmp_path):
+    """Index rows carry the first <p> headline + an ISO mtime date, offline."""
+    from research_os.tools.actions.synthesis.scaffold import rebuild_updates_index
+
+    u = tmp_path / "synthesis" / "updates"
+    u.mkdir(parents=True)
+    (u / "step-03-eda.html").write_text(
+        '<!doctype html><html lang="en">'
+        '<body data-archetype="step-report">'
+        "<h1>Step 3 — baseline EDA</h1>"
+        "<p>Accuracy reached 0.84, a 6pp lift over baseline.</p>"
+        "</body></html>",
+        encoding="utf-8",
+    )
+    out = rebuild_updates_index(tmp_path)
+    assert out["status"] == "success"
+    idx = (u / "index.html").read_text(encoding="utf-8")
+    assert "Accuracy reached 0.84" in idx          # headline pulled
+    assert 'class="date"' in idx                   # date span rendered
+    assert 'class="headline"' in idx
+    # Still offline + still stamped as the navigation index (not a report).
+    assert "http://" not in idx and "https://" not in idx
+    assert 'data-archetype="updates-index"' in idx
+
+
+def test_updates_index_headline_truncated(tmp_path):
+    """A long first paragraph is clipped with an ellipsis."""
+    from research_os.tools.actions.synthesis.scaffold import rebuild_updates_index
+
+    u = tmp_path / "synthesis" / "updates"
+    u.mkdir(parents=True)
+    long_p = "y" * 400
+    (u / "step-01-x.html").write_text(
+        '<!doctype html><html lang="en"><body data-archetype="step-report">'
+        f"<h1>Step 1</h1><p>{long_p}</p></body></html>",
+        encoding="utf-8",
+    )
+    rebuild_updates_index(tmp_path)
+    idx = (u / "index.html").read_text(encoding="utf-8")
+    assert "…" in idx
+    assert "y" * 400 not in idx
+
+
+def test_stage_step_figures_picks_focal_and_copies(tmp_path):
+    """stage_step_figures copies a step's figures + flags the focal one."""
+    from research_os.tools.actions.synthesis.scaffold import stage_step_figures
+
+    figs = tmp_path / "workspace" / "03_baseline_eda" / "outputs" / "figures"
+    figs.mkdir(parents=True)
+    (figs / "03_main.png").write_bytes(b"\x89PNG focal")
+    (figs / "aux_hist.png").write_bytes(b"\x89PNG aux")
+
+    out = stage_step_figures(tmp_path, "3")
+    assert out["status"] == "success"
+    assert out["focal"] == "figures/03_main.png"
+    staged_names = {s["filename"] for s in out["staged"]}
+    assert staged_names == {"03_main.png", "aux_hist.png"}
+    focal_flags = {s["filename"]: s["focal"] for s in out["staged"]}
+    assert focal_flags["03_main.png"] is True
+    assert focal_flags["aux_hist.png"] is False
+    # Files actually landed next to where the report will live.
+    dest = tmp_path / "synthesis" / "updates" / "figures"
+    assert (dest / "03_main.png").exists()
+    assert (dest / "aux_hist.png").exists()
+
+
+def test_stage_step_figures_empty_when_no_figures(tmp_path):
+    """No figures → empty status, never raises, report can still be authored."""
+    from research_os.tools.actions.synthesis.scaffold import stage_step_figures
+
+    (tmp_path / "workspace" / "01_x").mkdir(parents=True)
+    out = stage_step_figures(tmp_path, "1")
+    assert out["status"] == "empty"
+    assert out["staged"] == []
+
+
+def test_stage_step_figures_unresolvable_step(tmp_path):
+    """An unknown step resolves to empty, not an error."""
+    from research_os.tools.actions.synthesis.scaffold import stage_step_figures
+
+    (tmp_path / "workspace").mkdir(parents=True)
+    out = stage_step_figures(tmp_path, "99")
+    assert out["status"] == "empty"
+    assert out["staged"] == []


### PR DESCRIPTION
Bumps version to v3.11.0. Step report adoption: deliverable chooser surfacing, end-of-step nudge, figure staging, updates-index polish, and the guidance-first doctrine example. See CHANGELOG.md for details.

Gate: preflight 33/33, ruff clean, full pytest suite green. 19 step-report tests.