### PR TITLE
docs: accuracy pass + realistic worked-scenarios overhaul (v3.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,47 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
-## [3.11.1] — documentation accuracy pass (2026-06-22)
+## [3.11.1] — documentation accuracy + worked-scenarios pass (2026-06-22)
 
 A PATCH release. Docs-only — no code, tool, or protocol behaviour
 changed. The whole `docs/` tree and the README were audited against the
-live registry, protocol catalogue, and CLI, and corrected wherever they
-had drifted.
+live registry, protocol catalogue, and CLI, corrected wherever they had
+drifted, and substantially enriched with realistic end-to-end examples.
+
+### Added
+
+- **`docs/SCENARIOS.md`** — a new doc with seven complete, realistic,
+  end-to-end worked examples: a grad student turning a messy sensor CSV
+  into a paper + poster; a postdoc reproducing a published bioinformatics
+  result and finding it normalization-sensitive; a PI assembling an NIH
+  R01 from finished work; an engineer benchmarking their own Rust tool in
+  `tool_build` mode; a qualitative researcher taking 18 interview
+  transcripts to a publishable paper + dashboard; bringing a
+  half-finished project into Research OS mid-stream; and a quick
+  one-figure job. Each names a researcher, shows the data on disk, the
+  exact prompts typed, the protocols that fire, and what lands in
+  `synthesis/`. Every protocol, tool, CLI flag, and protocol step
+  referenced was verified against the live registry. Linked from the
+  README, the docs index, USE_CASES, START, RESEARCHER_GUIDE, and FAQ.
+
+### Improved
+
+- **`docs/FAQ.md`** — replaced the stale v2.0.0-retrospective lead-in
+  (which greeted every reader of a 3.11.x product with a two-year-old
+  migration note) with a topic-grouped "common questions" entry point +
+  jump links. The v2.0.0 detail was preserved verbatim under a clearly
+  labelled "Version history (in depth)" section.
 
 ### Fixed
 
+- **`docs/FAQ.md`** — the "add a custom MCP tool" answer pointed at the
+  long-removed monolithic `src/research_os/server.py`; corrected to the
+  split `server/tool_definitions/*.py` + `server/handlers/*.py` layout.
+- **Cross-doc links** — fixed three broken/stale internal anchors
+  (`PROTOCOLS.md → TOOLS.md` theory-pack section that no longer exists;
+  `README.md → RESEARCHER_GUIDE.md` config section that renumbered from
+  §9 to §8) and verified zero broken links across the whole `docs/` tree
+  + README.
 - **`docs/TOOLS.md`** — added the 8 live tools that had no entry
   (`tool_build`, `tool_git`, `tool_deliverable_chooser`, `tool_explain`,
   `tool_finalize_project`, `tool_skills`, and the `wet_lab` pack's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ Versioning: [SemVer](https://semver.org).
 
 ---
 
+## [3.11.1] — documentation accuracy pass (2026-06-22)
+
+A PATCH release. Docs-only — no code, tool, or protocol behaviour
+changed. The whole `docs/` tree and the README were audited against the
+live registry, protocol catalogue, and CLI, and corrected wherever they
+had drifted.
+
+### Fixed
+
+- **`docs/TOOLS.md`** — added the 8 live tools that had no entry
+  (`tool_build`, `tool_git`, `tool_deliverable_chooser`, `tool_explain`,
+  `tool_finalize_project`, `tool_skills`, and the `wet_lab` pack's
+  `tool_wet_lab_checksum_raw` + `tool_wet_lab_run_log_init`). The doc
+  now covers all 152 live tools with zero stale entries (verified by a
+  cross-reference against `TOOL_DEFINITIONS`).
+- **`docs/PROTOCOLS.md`** — corrected the header from "100+ protocols /
+  nine categories" to the accurate **130+ protocols across thirteen
+  categories**, and regenerated the auto-catalogue block via
+  `scripts/regen_protocols_doc.py` so per-category counts (methodology
+  44, synthesis 22) and the previously-undocumented `build`,
+  `exploration`, `notebook`, and `program` categories are all present.
+- **`docs/CLI.md`** — the top command table listed only 7 of the 10
+  real subcommands; added `hermes`, `route`, and `refresh`, rewrote the
+  intro, and added a full `research-os refresh` reference section.
+- **`docs/START.md`** — fixed both "seven commands" references to the
+  accurate ten, and added the missing `hermes` / `route` / `refresh`
+  examples to the cheatsheet.
+- **`docs/AI_GUIDE.md`** — corrected the protocol-categories heading
+  ("100+ protocols, organised in 9" → "130+ protocols") and added the
+  `build`, `exploration`, `notebook`, and `program` router intent
+  classes to the category table, with a pointer to `PROTOCOLS.md` for
+  the authoritative folder roster.
+- Verified zero broken internal doc links, README Python badge matches
+  the packaging classifiers (3.10 / 3.11 / 3.12), and the README IDE
+  list matches the wizard's supported targets.
+
+---
+
 ## [3.11.0] — step report adoption (2026-06-22)
 
 A MINOR release that makes the **step report** (added in 3.10.0)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ authors:
 license: MIT
 repository-code: "https://github.com/VibhavSetlur/Research-OS"
 url: "https://github.com/VibhavSetlur/Research-OS"
-version: 3.11.0
+version: 3.11.1
 date-released: 2026-06-22
 keywords:
   - research-data-management

--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ State, plan, hypotheses, dead-ends, and active drafts persist. Tomorrow's sessio
 
 → Full catalogue: **[USE_CASES.md](docs/USE_CASES.md)** (by role · by goal · by output type)
 
+→ See it on real projects: **[SCENARIOS.md](docs/SCENARIOS.md)** — seven complete worked examples, from a messy CSV to a published paper, with the exact prompts.
+
 ---
 
 ## What you actually see
@@ -274,7 +276,7 @@ system that won't let any of those things land in your final paper.
 | If you're… | Read this |
 |---|---|
 | **New here** | [docs/START.md](docs/START.md) — install + first project in 15 min |
-| **Looking for an example** | [docs/USE_CASES.md](docs/USE_CASES.md) — what to say for what you want |
+| **Looking for an example** | [docs/SCENARIOS.md](docs/SCENARIOS.md) — seven complete worked projects · [docs/USE_CASES.md](docs/USE_CASES.md) — what to say for what you want |
 | **Going deep** | [docs/RESEARCHER_GUIDE.md](docs/RESEARCHER_GUIDE.md) — the full workflow guide |
 | **Wiring an IDE** | [docs/SETUP.md](docs/SETUP.md) — Claude Code, Cursor, VS Code, etc. |
 | **Stuck** | [docs/FAQ.md](docs/FAQ.md) — common questions |
@@ -301,7 +303,7 @@ interaction:
   ambiguity_posture: ask_when_uncertain  # vs take_best_default
 ```
 
-→ Full reference: **[RESEARCHER_GUIDE.md § config](docs/RESEARCHER_GUIDE.md#9-the-config-file)**
+→ Full reference: **[RESEARCHER_GUIDE.md § config](docs/RESEARCHER_GUIDE.md#8-configuration-inputsresearcher_configyaml)**
 
 ---
 

--- a/docs/AI_GUIDE.md
+++ b/docs/AI_GUIDE.md
@@ -354,12 +354,18 @@ benefits from the right files being in the right place.
 
 ---
 
-## Protocol categories (100+ protocols, organised in 9)
+## Protocol categories (130+ protocols)
 
 Every protocol carries `scope_tags: {domain, audience, workflow_shape}`
 + a `tier` annotation. `tool_route` surfaces both in
 `why_matched`, so when the router returns alternatives you can rank
-them by tier compatibility.
+them by tier compatibility. The table below groups by router
+intent_class (a slightly higher-level view than the on-disk folders —
+e.g. `discover` is a virtual class backed by a shortcut tool, and
+`audit + reproducibility` merges two folders). For the exact on-disk
+folder roster + per-category counts, see
+[PROTOCOLS.md](PROTOCOLS.md); for the live flat list call
+`tool_protocols_list`.
 
 | Category | What it covers |
 |---|---|
@@ -370,7 +376,10 @@ them by tier compatibility.
 | literature | search + systematic review + evidence synthesis + comparative review + `literature_per_step` (per-step findings_vs_literature.md loop) |
 | writing | per-section drafting (methods / results / discussion / limitations / end_matter) |
 | visualization | figures (rules / workflow / critique / multi-panel / arc / a11y / interactive) |
-| synthesis | final deliverables (paper / abstract / poster / dashboard / slides / lay / handout / report / grant / progress / from_inputs / null / cover_letter / title / manuscript_outline / journal_selection / defense_prep / printable / deliverable_design / humanities_essay_structure / reviewer_response) |
+| synthesis | final deliverables (paper / abstract / poster / dashboard / slides / lay / handout / report / grant / progress / from_inputs / null / cover_letter / title / manuscript_outline / journal_selection / defense_prep / printable / deliverable_design / synthesis_step_report / humanities_essay_structure / reviewer_response) |
+| build | the `tool_build` workspace mode lifecycle (spec_and_design / implement_iteration / test_strategy / benchmark_vs_baseline / release_and_changelog) |
+| exploration | the exploration workspace mode (loop / triage / promote) |
+| notebook + program | interactive notebook-driven analysis + multi-project program scaffolding |
 | audit + reproducibility | quality audit + pre-submission checklist + provenance completeness + repro audit + `tool_audit(scope='step', dimension='literature')` gate |
 
 If a category looks like it should have a folder but you can't find one

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,16 +1,20 @@
 # Research OS — CLI reference
 
-`research-os` ships these top-level commands. Three set up + run the
-MCP server; the others diagnose health and emit shell completions.
+`research-os` ships ten top-level commands. A few set up + run the MCP
+server; the rest wire integrations, preview routing, diagnose health,
+keep project templates fresh, and emit shell completions.
 
 | Command            | What it does                                         |
 | ------------------ | ---------------------------------------------------- |
 | `research-os init` | Scaffold a workspace ready for any AI IDE.           |
 | `research-os ide`  | Add / remove / list AI IDE MCP configs.              |
 | `research-os mcp`  | Compose third-party MCP servers into IDE configs.    |
+| `research-os hermes` | Wire Research-OS into Hermes Agent (`~/.hermes/config.yaml`). |
+| `research-os route` | Preview the protocol router for a prompt (no IDE needed). |
 | `research-os api-key` | Manage api_keys in `inputs/researcher_config.yaml`. |
 | `research-os start`| Run the MCP server (your IDE auto-launches it).      |
 | `research-os doctor` | Diagnose install + workspace health (this page).   |
+| `research-os refresh` | Refresh project copies of bundled templates (drift check). |
 | `research-os completion` | Print a sourceable shell-completion script.    |
 
 See `research-os <command> --help` for full flag reference.
@@ -286,6 +290,40 @@ research-os doctor --workspace /path/to/my-research
 Every check entry has `name`, `status`, `message`, and `scope`
 (`install` or `workspace`). When a check produced a fix hint, the
 entry also carries a `fix` field.
+
+---
+
+## `research-os refresh`
+
+Detects drift between a project's copies of the bundled templates
+(`AGENTS.md`, `CLAUDE.md`, `.claude/rules/research-os.md`, and the
+per-IDE rule files) and the versions shipped with the installed
+`research-os`. The wizard copies templates once at init, so a project
+that has lived across a few releases can be teaching the AI a stale tool
+surface or out-of-date hard rules. `refresh` shows the gap and, with
+`--write`, overwrites the project copies in place.
+
+Read-only by default. `--check` exits non-zero on drift so CI can fail
+when a project falls out of sync.
+
+```bash
+research-os refresh                 # report drift (default, read-only)
+research-os refresh --check         # report + exit 1 if any drift
+research-os refresh --write         # prompt per-file, then overwrite
+research-os refresh --write --yes   # overwrite every drifted file, no prompts
+research-os refresh --regen-readme  # also regenerate project-root README.md
+research-os refresh --json          # machine-readable report
+```
+
+| Flag             | Meaning                                                            |
+| ---------------- | ----------------------------------------------------------------- |
+| `--check`        | Report only; exit non-zero if any project copy has drifted.       |
+| `--write`        | Overwrite drifted project copies with the bundled template.       |
+| `-y`, `--yes`    | With `--write`, skip the per-file confirmation prompt.            |
+| `--regen-readme` | Also regenerate the project-root `README.md` with the current step inventory + synthesis deliverable list (use at finalize). |
+| `--workspace`    | Explicit workspace path (default: walk up from CWD).              |
+| `--json`         | Emit JSON instead of the human-readable report.                  |
+| `--no-color`     | Disable ANSI styling (auto-disabled when `NO_COLOR` is set).      |
 
 ---
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,52 +1,14 @@
 # FAQ
 
-## v2.0.0 (the short answer)
+Common questions, grouped by topic. New here? Skim **Setup** and
+**Workflow** first. For complete worked examples of real projects, see
+[SCENARIOS.md](SCENARIOS.md); for the role × goal × output map, see
+[USE_CASES.md](USE_CASES.md).
 
-### What changed in v2.0.0?
-
-The headline shape change is a **tool surface consolidation
-(344 → 144 live)** plus a flip of `sys_protocol_get` to default
-`format='summary'`. Both are breaking on paper but **every legacy
-tool name still dispatches via alias for the v2.0.x runway** — most
-projects upgrade with zero call-site edits. After
-`pip install --upgrade research-os`, run **`research-os doctor`** for
-a 20+ install + workspace health report (exit 0 = all pass,
-1 = warn-only, 2 = fail). See
-`CHANGELOG.md [2.0.0]` for the full upgrade
-recipe.
-
-Other v2.0.0 highlights:
-
-* **MCP `instructions` field on the initialize handshake** — names
-  the canonical boot ritual (`sys_boot → tool_route →
-  sys_protocol_get(format=summary) → sys_active_tools`) so a fresh
-  MCP client sees it instead of discovering it.
-* **`tool_route.recommended_action` + `why_matched`** — the router
-  returns a literal next-call string and a short rationale on every
-  match, so the AI doesn't burn a turn deciding what to call next.
-* **Audit-as-data** — every audit emits a JSON companion + appends
-  to the cross-audit ledger at
-  `workspace/logs/.audit_findings.jsonl`. Query with
-  `tool_audit_findings(operation='query', severity='block')`.
-* **AI-direct synthesis authoring (v2.3.0)** — the AI writes
-  `synthesis/paper.typ` / `slides.typ` / `poster.typ` / `essay.typ` /
-  `dashboard.html` directly, following the matching synthesis
-  protocol. Tools validate (`tool_synthesis_check`) and compile
-  (`tool_typst_compile`); the auto-generators that produced rigid
-  output were retired.
-* **`research-os doctor`** — 20+ install + workspace health checks.
-* **`tier:` + `scope_tags`** on every protocol — wires the
-  router to filter candidates by project lifecycle and applicability.
-* **New discovery tools** — `tool_protocols_list` + `tool_tools_list`
-  return flat filterable catalogues.
-
-The Phase 15b 20-agent validation moved the mean rating
-**6.35 → 7.70 (+21%)** with **HIGH-friction items 124 → 63 (-49%)**;
-v2.0.0 ships with a documented YELLOW caveat that the absolute
-release-gate targets (calibrated against a v3-grade product) were
-not met. See
-`CHANGELOG.md [2.0.0]` for the full
-analysis.
+Jump to: [Setup](#setup) · [Setup & configuration](#setup-configuration)
+· [Workflow](#workflow) · [Outputs](#outputs) ·
+[State / robustness](#state-robustness) · [Power users](#power-users) ·
+[Version history](#version-history-in-depth)
 
 ---
 
@@ -390,9 +352,11 @@ it up automatically; no code changes needed. The standard
 ### Can I add a custom MCP tool?
 
 Yes. Implement the function in `src/research_os/tools/actions/<group>/<file>.py`,
-add a JSON schema to `TOOL_DEFINITIONS` in `src/research_os/server.py`, register
-the handler in `_HANDLERS`. Reference the new tool from at least one
-protocol so it doesn't become dead code. See
+add a JSON schema to `TOOL_DEFINITIONS` in the matching
+`src/research_os/server/tool_definitions/*.py` module, and register the
+handler in the matching `src/research_os/server/handlers/*.py` module's
+`HANDLERS` map. Reference the new tool from at least one protocol so it
+doesn't become dead code. See
 [CONTRIBUTING.md](../CONTRIBUTING.md).
 
 ### Can I run Research OS without the synthesis features?
@@ -412,6 +376,31 @@ Two patterns:
   pointers to the sibling project.
 
 ---
+
+## Version history (in depth)
+
+> Historical reference. These entries explain features introduced in
+> earlier major versions (still current behaviour unless a later
+> CHANGELOG entry says otherwise). For the live release history, see
+> [`../CHANGELOG.md`](../CHANGELOG.md).
+
+### What changed in v2.0.0?
+
+The headline shape change was a **tool surface consolidation
+(344 → 144 live)** plus a flip of `sys_protocol_get` to default
+`format='summary'`. Both were breaking on paper but **every legacy
+tool name still dispatches via alias** — most projects upgraded with
+zero call-site edits. After `pip install --upgrade research-os`, run
+**`research-os doctor`** for an install + workspace health report
+(exit 0 = all pass, 1 = warn-only, 2 = fail). See `CHANGELOG.md [2.0.0]`
+for the full upgrade recipe. Other v2.0.0 highlights: the MCP
+`instructions` field on the initialize handshake (names the canonical
+boot ritual), `tool_route.recommended_action` + `why_matched`,
+audit-as-data (the `.audit_findings.jsonl` ledger), `tier:` +
+`scope_tags` on every protocol, and the `tool_protocols_list` /
+`tool_tools_list` discovery tools. v2.3.0 added AI-direct synthesis
+authoring (the AI writes `synthesis/paper.typ` etc. directly; the rigid
+auto-generators were retired).
 
 ## v2.0.0 — new features (in depth)
 

--- a/docs/PROTOCOLS.md
+++ b/docs/PROTOCOLS.md
@@ -290,7 +290,7 @@ proof", "iterate on the proof", "formalise in Lean / Coq".
 
 Three theory-only tools ship with the pack: `tool_theory_math_lean_check`,
 `tool_theory_math_coq_check`, `tool_theory_math_dep_graph`. See
-[TOOLS.md § Theory + math pack](TOOLS.md#theory--math-pack).
+[TOOLS.md](TOOLS.md#catalogue-alphabetical-by-canonical-name) (alphabetical catalogue).
 
 ### Audit + reproducibility
 

--- a/docs/PROTOCOLS.md
+++ b/docs/PROTOCOLS.md
@@ -1,6 +1,6 @@
 # Protocol Reference
 
-Research OS ships **100+ core YAML protocols** organised into nine
+Research OS ships **130+ core YAML protocols** organised into thirteen
 categories, plus pack-specific protocols (humanities, qualitative,
 theory_math, wet_lab, engineering) when those packs are installed.
 Each protocol is a sequence of steps the AI should follow, with
@@ -10,26 +10,34 @@ explicit `expected_outputs`, a `next_protocol` pointer, a
 indexed in `src/research_os/protocols/_router_index.yaml` for
 hierarchical + semantic routing via `tool_route`.
 
+Counts below are accurate as of v3.11.1. The catalogue grows between
+releases; run `tool_protocols_list` for the live, flat list with
+filters rather than trusting a hardcoded number.
+
 | Category | Count | What's in it |
 |---|---|---|
-| `methodology/` | 43 | Method pickers + per-family deep workflows (causal, ML, Bayesian, time-series, clinical, qualitative, mixed-methods, simulation, replication, ablation, pilot, evaluation design, hyperparameter sweep design, ethics review, EDA + hypothesis generation, method comparison, data-quality audit, power analysis, reproduction, methodological consultation), plus the cross-cutting protocols `pick_tool_stack` (R vs Python per sub-task), `mixed_language_orchestration` (Python↔R↔Bash composition), `qualitative_pii_redaction`, `bootstrapping_design`, `cox_ph_diagnostics`, `data_management_plan`, `fairness_audit`, `inter_rater_reliability`, `interview_guide_design`, `mcp_ecosystem_integration`, `missing_data_strategy`, `multiple_comparisons`, `survey_design`, `uncertainty_quantification`. |
-| `synthesis/` | 20 | Paper, abstract, poster, dashboard, grant, report, slides, lay summary, progress update, cover letter, title workshop, handout, null-findings companion, synthesis-from-inputs, manuscript_outline, journal_selection, defense_prep, printable, `humanities_essay_structure`, `reviewer_response`. |
+| `methodology/` | 44 | Method pickers + per-family deep workflows (causal, ML, Bayesian, time-series, clinical, qualitative, mixed-methods, simulation, replication, ablation, pilot, evaluation design, hyperparameter sweep design, ethics review, EDA + hypothesis generation, method comparison, data-quality audit, power analysis, reproduction, methodological consultation, meta-analysis, spatial, survey psychometrics, preregistration), plus the cross-cutting protocols `pick_tool_stack` (R vs Python per sub-task), `mixed_language_orchestration` (Python↔R↔Bash composition), `qualitative_pii_redaction`, `bootstrapping_design`, `cox_ph_diagnostics`, `data_management_plan`, `fairness_audit`, `inter_rater_reliability`, `interview_guide_design`, `mcp_ecosystem_integration`, `missing_data_strategy`, `multiple_comparisons`, `survey_design`, `uncertainty_quantification`, `tool_discovery`, `external_tool_setup`, `deep_domain_research`. |
+| `synthesis/` | 22 | Paper, abstract, poster, dashboard, grant, report, slides, lay summary, progress update, cover letter, title workshop, handout, null-findings companion, synthesis-from-inputs, manuscript_outline, journal_selection, defense_prep, printable, `deliverable_design`, `synthesis_step_report` (per-step interim report), `humanities_essay_structure`, `reviewer_response`. |
 | `guidance/` | 19 | Session boot / resume / handoff / autopilot / collaboration, intake, iterative planning, dead-end routing, hypothesis + glossary tracking, mid-pipeline entry, code review, peer-review response, scope-clarification, constructive_disagreement, revise_and_resubmit. |
 | `visualization/` | 14 | Figure guidelines, viz workflow, single-figure critique, multi-panel composition, narrative arc, colour-accessibility audit, interactive figure design, animation, distribution comparison, geospatial, interactive dashboard design, network, showcase, uncertainty. |
 | `writing/` | 10 | Per-section drafting (methods / results / discussion / limitations / end-matter), writing core rules, citations ledger, conclusions, analysis log, README. |
 | `literature/` | 5 | Search, systematic review (PRISMA), evidence synthesis (GRADE), comparative paper review, `literature_per_step` (per-step search → download → cite → write `findings_vs_literature.md` with `AGREES \| DISAGREES \| EXTENDS \| DEFERRED \| IMPORTED_AS_CITED` verdicts). |
+| `build/` | 5 | The **tool_build** workspace mode lifecycle: spec_and_design, implement_iteration, test_strategy, benchmark_vs_baseline, release_and_changelog. |
 | `audit/` | 3 | Master audit + validation, pre-submission checklist, provenance completeness. |
+| `exploration/` | 3 | The **exploration** workspace mode: exploration_loop, exploration_triage, exploration_promote (promote a probe to a real step when it earns it). |
 | `domain/` | 2 | Domain classification, research-design + sample-size justification. |
 | `reproducibility/` | 1 | Per-step env lock, seed verification, container generation. |
-| **Core total** | **all** | All protocols carry `tier:` + `scope_tags`. |
+| `notebook/` | 1 | notebook_workflow — interactive notebook-driven analysis. |
+| `program/` | 1 | program_setup — multi-project program scaffolding. |
+| **Core total** | **130** | All protocols carry `tier:` + `scope_tags`. |
 
 Pack-specific protocols (loaded only when the matching pack is
-installed) add ~36 more across `humanities/` (archival, citation,
+installed) add more across `humanities/` (archival, citation,
 method, output, textual), `qualitative/` (coding, method, output,
-validity), and `theory_math/` (conjecture, formal, method, output,
-proof). Run `sys_packs_installed` to see which packs are active in
-your project and `tool_protocols_list` for the flat catalogue with
-filters.
+validity), `theory_math/` (conjecture, formal, method, output,
+proof), `wet_lab/`, and `engineering/`. Run `sys_packs_installed` to
+see which packs are active in your project and `tool_protocols_list`
+for the flat catalogue with filters.
 
 The protocol surface deliberately covers BOTH the canonical
 data → publication pipeline AND the partial / off-axis workflows
@@ -399,7 +407,7 @@ it via `_router_index.yaml`; load it with `sys_protocol_get`.
 <!-- AUTO:PROTOCOL_CATALOGUE_START -->
 <!-- AUTO-GENERATED by scripts/regen_protocols_doc.py — DO NOT EDIT BY HAND -->
 
-_All core protocols, grouped by category, alphabetised within each._
+_All 130 protocols, grouped by category, alphabetised within each._
 
 ### `audit/` (3 protocols)
 
@@ -409,12 +417,30 @@ _All core protocols, grouped by category, alphabetised within each._
 | `pre_submission_checklist` | Final ready-to-submit gate. Walks the project through every |
 | `provenance_completeness` | Every figure, table, model artefact, and report output in the workspace |
 
+### `build/` (5 protocols)
+
+| Protocol | One-liner |
+|---|---|
+| `benchmark_vs_baseline` | Reason about how to measure the tool honestly against the right |
+| `implement_iteration` | The core build loop for tool_build mode — the analog of |
+| `release_and_changelog` | Turn a set of committed increments into a release a consumer can adopt |
+| `spec_and_design` | The opening move of a tool_build workspace. Before any code, pin down |
+| `test_strategy` | Reason about what testing regime actually fits the tool being built — |
+
 ### `domain/` (2 protocols)
 
 | Protocol | One-liner |
 |---|---|
-| `domain_analysis` | Classify the research domain, surface the relevant reporting standards, and list domain-specific biases to… |
-| `research_design` | Choose the right study design (RCT, cohort, case-control, etc.) and compute / justify the sample size. |
+| `domain_analysis` | Classify the research domain, surface the reporting standard the field actually uses, and list the biases… |
+| `research_design` | Choose the study design that fits the question (interventional vs observational, comparative vs descriptive,… |
+
+### `exploration/` (3 protocols)
+
+| Protocol | One-liner |
+|---|---|
+| `exploration_loop` | The core loop of an exploration-mode workspace: a tight, cheap |
+| `exploration_promote` | The bridge out of exploration mode: take a scratch probe that earned it |
+| `exploration_triage` | The orienting pass for an exploration-mode workspace facing a fresh, |
 
 ### `guidance/` (19 protocols)
 
@@ -428,7 +454,7 @@ _All core protocols, grouped by category, alphabetised within each._
 | `collaboration_handoff` | Package the project for handoff to a human collaborator who is |
 | `constructive_disagreement` | Protocol for the case where the AI's grounded judgement disagrees |
 | `dead_end_routing` | What to do when an experiment path fails or a methodology proves unworkable. Preserves the failed path and… |
-| `glossary_update` | Add or refine a definition in `glossary.md` (in the project's `docs/`). Run this protocol the first time any non-trivial term appears… |
+| `glossary_update` | Add or refine a definition in docs/glossary.md. Run this protocol the first time any non-trivial term appears… |
 | `hypothesis_tracking` | Maintain a clear ledger of active, supported, and refuted hypotheses across the project. |
 | `iterative_planning` | For researchers who want the AI to PROPOSE next steps rather than dictate them. Iteratively assesses state +… |
 | `mid_pipeline_entry` | Routing protocol for researchers entering Research-OS with WORK ALREADY |
@@ -445,12 +471,12 @@ _All core protocols, grouped by category, alphabetised within each._
 | Protocol | One-liner |
 |---|---|
 | `comparative_paper_review` | Compare-and-contrast review of TWO OR MORE papers. Distinct from: |
-| `evidence_synthesis` | Build an evidence table from the literature corpus, grade each entry, and flag contradictions. |
+| `evidence_synthesis` | Build an evidence table from the literature corpus, grade each entry on the field's certainty framework, and… |
 | `literature_per_step` | After every analysis step writes its findings, RO grounds those |
-| `literature_search` | Systematic search across 2-4 academic databases. Produces a |
+| `literature_search` | Multi-database literature search across several academic providers. |
 | `systematic_review` | Full PRISMA workflow for a primary systematic review or meta-analysis project. |
 
-### `methodology/` (43 protocols)
+### `methodology/` (44 protocols)
 
 | Protocol | One-liner |
 |---|---|
@@ -492,11 +518,24 @@ _All core protocols, grouped by category, alphabetised within each._
 | `replication_study` | Re-execute a previously published analysis with explicit comparison to |
 | `reproduction_attempt` | Attempt to REPRODUCE a published analysis — rerun the authors' |
 | `simulation_studies` | Monte Carlo, agent-based, discrete-event, or in-silico studies. Follows |
-| `survey_design` | survey_psychometrics analyses a survey that already exists. THIS |
+| `spatial_analysis` | Reasoning scaffold for analysing data with a spatial structure — |
+| `survey_design` | Distinct from survey_psychometrics, which analyses a survey that |
 | `survey_psychometrics` | Reasoning scaffold for analysing survey / multi-item-scale / |
 | `timeseries_analysis` | First-class protocol for analyses where time order matters: |
 | `tool_discovery` | Find the right Python / R / Julia library for a specific task and verify it can be installed. |
 | `uncertainty_quantification` | Predictive models report point estimates by default. Calibrated |
+
+### `notebook/` (1 protocols)
+
+| Protocol | One-liner |
+|---|---|
+| `notebook_workflow` | The home loop of a notebook (Jupyter-first) workspace. The unit of work |
+
+### `program/` (1 protocols)
+
+| Protocol | One-liner |
+|---|---|
+| `program_setup` | The opening move of a multi_study (program) workspace. Before any single |
 
 ### `reproducibility/` (1 protocols)
 
@@ -504,29 +543,31 @@ _All core protocols, grouped by category, alphabetised within each._
 |---|---|
 | `reproducibility` | Lock down environments, verify the pipeline runs end-to-end, and produce a Dockerfile for full portability. |
 
-### `synthesis/` (20 protocols)
+### `synthesis/` (22 protocols)
 
 | Protocol | One-liner |
 |---|---|
 | `defense_prep` | A dissertation defense, a job talk, or a high-stakes conference |
-| `humanities_essay_structure` | Interpretive-structure protocol for the humanities essay form. The |
+| `deliverable_design` | The design SKILL for shareable research deliverables — the deliverable-level |
+| `humanities_essay_structure` | Guide the AI to author `synthesis/essay.typ` directly as a |
 | `journal_selection` | Picking the wrong venue wastes months. The right venue is the |
 | `manuscript_outline` | Drafting a paper before outlining is the most common source of |
-| `printable` | One protocol for every print-first deliverable. The protocol is |
+| `printable` | Guide the AI to author a printable deliverable directly. One |
 | `reviewer_response` | Run a 7-persona adversarial self-review against the FINISHED paper |
 | `synthesis_abstract` | Generate a structured / unstructured abstract tuned to the target venue. |
 | `synthesis_cover_letter` | Draft the cover letter that accompanies a journal submission. The |
-| `synthesis_dashboard` | Generate a polished single-file HTML dashboard that reads as |
+| `synthesis_dashboard` | Guide the AI to author `synthesis/dashboard.html` as a **custom, |
 | `synthesis_from_inputs` | Synthesis for the case where the researcher has finished analyses, |
-| `synthesis_grant` | Draft a grant proposal narrative tuned to the target funder (NIH / NSF / Wellcome / ERC / DoE / DARPA /… |
-| `synthesis_handout` | Redirect stub. The handout / one-pager content was consolidated |
+| `synthesis_grant` | Guide the AI to author `synthesis/grant.typ` directly as a grant |
+| `synthesis_handout` | Redirect stub. The handout / one-pager content lives in |
 | `synthesis_lay_summary` | Compile a plain-language summary of the project for a NON-EXPERT |
 | `synthesis_null_findings` | Assemble a publishable companion document for findings that DIDN'T |
-| `synthesis_paper` | Compile the final IMRAD paper into synthesis/paper.md (and |
-| `synthesis_poster` | Redirect stub. Poster content was consolidated into |
+| `synthesis_paper` | Guide the AI to author `synthesis/paper.typ` directly, section by |
+| `synthesis_poster` | Redirect stub. Poster content lives in |
 | `synthesis_progress_update` | Compile a short progress update — the kind a researcher sends their |
 | `synthesis_report` | Compile a non-journal report for internal stakeholders, clients, or a technical audience. |
-| `synthesis_slides` | Compile a presentation deck — lab meeting, conference talk, defense, |
+| `synthesis_slides` | Guide the AI to author `synthesis/slides.typ` directly (Touying |
+| `synthesis_step_report` | Guide the AI to author a **self-contained, presentation-grade visual |
 | `synthesis_title_workshop` | Generate, iterate, and pick a title for a paper / abstract / |
 
 ### `visualization/` (14 protocols)
@@ -553,8 +594,8 @@ _All core protocols, grouped by category, alphabetised within each._
 | Protocol | One-liner |
 |---|---|
 | `writing_analysis_log` | Format for structured entries appended to `workspace/analysis.md` — |
-| `writing_citations` | Maintain workspace/citations.md so every claim is grounded and every citation is verified online. |
-| `writing_conclusions` | How to write per-step conclusions.md. Called by analysis_plan's document_conclusions step. |
+| `writing_citations` | Maintain workspace/citations.md so every claim is grounded and every |
+| `writing_conclusions` | How to write per-step `workspace/<step>/conclusions.md`. Called by |
 | `writing_core` | Universal writing rules. Loaded implicitly by every writing/* and |
 | `writing_data_availability` | Draft the Data Availability, Code Availability, Author Contributions |
 | `writing_discussion` | Draft / iterate the Discussion section. The Discussion is where most |

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,8 +10,11 @@ You're using Research OS on your own research project.
 
 Start at [**START.md**](START.md) — install, first project, cheatsheet (~15 minutes). Then keep [**RESEARCHER_GUIDE.md**](RESEARCHER_GUIDE.md) open as you work — the full workflow guide.
 
+New here and want to see what a real project looks like? Read [**SCENARIOS.md**](SCENARIOS.md) — seven complete worked examples (messy CSV → paper, reproducing a paper, prepping an R01, benchmarking your own tool, interview transcripts → publication), with the exact prompts and what lands on disk.
+
 Supporting:
 
+- [SCENARIOS.md](SCENARIOS.md) — seven end-to-end worked examples: a named researcher, real data, the words they typed, what Research OS produced.
 - [GLOSSARY.md](GLOSSARY.md) — the vocabulary: step, path, PATH container, plan.md, conclusions.md, the data folders, the literature corpus, audit.md, and more.
 - [PROJECT_LAYOUT.md](PROJECT_LAYOUT.md) — the canonical directory layout: the safety backbone (`.os_state`, `inputs/`, `workspace/`, …) and what each workspace mode adds. The single source of truth for what lives where.
 - [USE_CASES.md](USE_CASES.md) — "I want to write a paper / build a poster / reproduce a result" → which protocol fires.

--- a/docs/RESEARCHER_GUIDE.md
+++ b/docs/RESEARCHER_GUIDE.md
@@ -183,6 +183,12 @@ above stay editable.
 
 ## 4. A typical session (narrative)
 
+> This section sketches the *shape* of a session with placeholder data.
+> For seven fully concrete, named-researcher walkthroughs — a messy
+> ecology CSV to a paper, reproducing a published bioinformatics result,
+> an R01 between meetings, benchmarking a Rust tool, 18 interview
+> transcripts to publication — see [SCENARIOS.md](SCENARIOS.md).
+
 ### 4.1 First time — set up the project
 
 > **You:** I dropped my CSV and a couple of papers in inputs/. Fill out

--- a/docs/SCENARIOS.md
+++ b/docs/SCENARIOS.md
@@ -1,0 +1,344 @@
+# Scenarios — Research OS on real projects, start to finish
+
+Most docs tell you *what* a tool or protocol does. This one shows you
+what a whole project actually feels like: a named researcher, real data
+on disk, the exact words they typed, what Research OS did in response,
+and what landed in `synthesis/` at the end.
+
+None of these are toy examples. Each one is a project shape we see
+constantly — a grad student with a messy CSV, a postdoc reproducing a
+paper, a PI prepping a grant, an engineer benchmarking their own code, a
+qualitative researcher with interview transcripts. Read the one closest
+to your situation, then steal the prompts.
+
+Conventions used below:
+
+- **You:** is what you type into your AI chat (Claude Code, Cursor,
+  Antigravity, …). Plain English. You never call MCP tools by hand.
+- **Research OS:** is what the server does behind the scenes — the
+  protocol it routes to, the files it writes, the gates it runs.
+- File paths are real and relative to your project root.
+
+---
+
+## Scenario 1 — Grad student, messy CSV, no hypothesis yet
+
+**Maya, 2nd-year PhD in ecology.** Her advisor handed her three years of
+field-station sensor data — `soil_moisture.csv`, 280k rows, 14 columns,
+some obviously broken sensors — and said "see if there's a paper in
+here." She has no hypothesis. She's never used Research OS.
+
+### Day 1 — get oriented without committing
+
+```bash
+cd ~/projects && research-os init drought-response --ide cursor
+# wizard asks "What are you building?" → she picks analysis (default)
+cp ~/Downloads/soil_moisture.csv drought-response/inputs/raw_data/
+```
+
+> **You:** I have soil_moisture.csv in inputs — 3 years of field sensor
+> readings, some sensors are flaky. I don't have a hypothesis yet.
+> Explore it and tell me if there's something worth chasing.
+
+**Research OS** routes to `methodology/exploratory_data_analysis` (not
+the full project pipeline — she said "no hypothesis yet"). It creates
+`workspace/01_baseline_eda/`, writes an atomic profiling script, runs
+it, and reports back: 4 of 22 sensors flatline after month 8 (stuck
+values), strong seasonal cycle, and a suspicious step-change in two
+plots in summer 2023.
+
+> **You:** The step-change in 2023 is interesting. What could cause
+> that, and is it real or an artifact?
+
+**Research OS** stays in EDA, branches a focused look at those two plots,
+checks for sensor recalibration timestamps in the metadata column, and
+writes `workspace/01_baseline_eda/conclusions.md`: the step-change
+aligns with a documented irrigation-system change, not a sensor fault —
+a *real* effect. That's the hypothesis seed.
+
+### Day 2 — turn the lead into a project
+
+> **You:** OK, there's a project here: does the 2023 irrigation change
+> shift the soil-moisture recovery curve after rain events? Set it up
+> properly.
+
+**Research OS** now routes to `guidance/project_startup`, calls
+`tool_intake_autofill`, proposes a research question + domain + a
+testable hypothesis (H1: post-2023 recovery half-life is shorter), and
+writes `inputs/intake.md` + `docs/research_overview.md`. Maya tweaks the
+wording and approves.
+
+The rest of the week is `guidance/analysis_plan` steps: rain-event
+detection (`02_event_detection`), recovery-curve fitting
+(`03_recovery_fits`), a pre/post comparison with a proper paired test
+(`04_prepost_test`). Each step is a numbered folder with its own script,
+figures, and `conclusions.md`. When she says *"actually use a
+mixed-effects model, sensors are nested in plots,"* the script bumps to
+`_v2` and the old one stays on disk.
+
+### End of project — the paper
+
+> **You:** Write this up for a journal. Then make a poster for the
+> department retreat.
+
+**Research OS** walks `synthesis/synthesis_paper`: workshops the title,
+drafts Methods → Results → Discussion → Limitations → Intro → Abstract,
+assembles end matter (data availability, CRediT), and runs
+`audit/pre_submission_checklist` for a GREEN/YELLOW/RED verdict. It
+flags one YELLOW: a causal phrasing in the Discussion for an
+observational design — she softens it. Then `synthesis/synthesis_poster`
+builds a Typst poster PDF with a QR back to the preprint.
+
+**What's on disk at the end:** `synthesis/paper.pdf`,
+`synthesis/poster.pdf`, and a `workspace/` tree where every figure
+traces back to the exact script and data slice that produced it.
+
+---
+
+## Scenario 2 — Postdoc reproducing a published analysis
+
+**Daniel, computational-biology postdoc.** A high-profile paper claims a
+gene-expression signature predicts treatment response. He wants to
+reproduce it before building on it — partly for a journal club, partly
+because the effect size looks too clean.
+
+```bash
+research-os init repro-signature --ide claude
+cp ~/papers/zhang2024.pdf repro-signature/inputs/literature/
+cp ~/data/GSE######_counts.tsv repro-signature/inputs/raw_data/
+```
+
+> **You:** I'm trying to reproduce Zhang 2024 (PDF in inputs/literature).
+> They claim a 12-gene signature predicts response from the counts
+> table I dropped in raw_data. Walk me through reproducing it.
+
+**Research OS** routes to `methodology/reproduction_attempt`. It reads
+the PDF, extracts the claimed pipeline (normalization → DE → signature
+scoring → AUC), and sets up `workspace/01_normalization/` to mirror
+their stated method. It logs a `mem_log(kind='decision')` every time the
+paper is ambiguous about a parameter, so the "where we diverged" list
+writes itself.
+
+> **You:** Their methods don't say which normalization they used. Try
+> the two most likely and see if the AUC is sensitive to it.
+
+**Research OS** uses `tool_sensitivity(operation='define')` to set up a
+small multiverse (TMM vs median-of-ratios), runs both, and reports: the
+headline AUC drops from 0.91 to 0.78 under the alternative
+normalization. That's the crux. The reproduction report
+(`workspace/logs/` + a `synthesis/synthesis_report`) documents it
+plainly: *partially reproducible; the central claim is normalization-
+sensitive and the paper under-specifies the choice.*
+
+**Why this matters:** the deliverable isn't "I got the same number." It's
+a defensible reproduction report with the divergence points pinned to
+evidence — exactly what a journal club or a rebuttal needs.
+
+---
+
+## Scenario 3 — PI prepping an R01 between meetings
+
+**Dr. Okafor, PI.** She has a finished Research OS project from last
+year (the paper's already out) and a Tuesday deadline to get an R01
+draft to her program officer. She's not analyzing anything new — she's
+repackaging completed work into a grant.
+
+> **You:** pick up where we left off
+
+**Research OS** loads `guidance/session_resume`, reads the prior state,
+and summarizes the completed project in two sentences.
+
+> **You:** Draft an NIH R01 from this project. Aim 1 is the published
+> work; Aims 2-3 are the obvious extensions we discussed.
+
+**Research OS** routes to `synthesis/synthesis_grant` (funder: nih_r01).
+It enforces the structure that reviewers expect: Specific Aims ≤ 1 page,
+each Aim with milestones + pitfalls + alternatives, Approach ≥ 1500
+words, ≥ 15 verified citations pulled from the project's existing
+bibliography (no hallucinated refs — they're verified against Crossref /
+PubMed). It drafts Aim 1 from the real results and scaffolds Aims 2-3
+from the decision log's "future work" entries.
+
+> **You:** The Specific Aims page is over a page. Tighten it and add a
+> lay-summary box for the program officer.
+
+**Research OS** trims to length and routes the box through
+`synthesis/synthesis_lay_summary` (audience: funder_lay_section).
+
+**On disk:** `synthesis/grant.pdf` plus a `lay_summary.md`. Every
+citation resolves. She edits the science, not the formatting.
+
+---
+
+## Scenario 4 — Engineer benchmarking their own tool (tool_build mode)
+
+**Sam, research software engineer.** They're writing a FASTQ
+deduplicator in Rust and need to prove it beats `seqkit rmdup` before
+claiming it in a methods paper. This is **building software**, not
+analyzing data — so it inits in `tool_build` mode.
+
+```bash
+research-os init fastq-dedup --workspace-mode tool_build --ide opencode
+```
+
+This seeds a different scaffold: `spec/`, `decisions/`, `eval/`,
+`milestones.md`, and an inner git repo. "Done" here means tests + build
++ eval pass, not figures.
+
+> **You:** Spec it out — it must handle paired-end reads and beat seqkit
+> rmdup on a 10 GB input by at least 2x wall-clock, same dedup results.
+
+**Research OS** routes to `build/spec_and_design`: records the
+acceptance criteria (the 2x target, identical output invariant), the
+interface contract, and the first ADRs in `decisions/`.
+
+> **You:** Implement the paired-end parser.
+
+**Research OS** routes to `build/implement_iteration`: writes the code
+in the inner repo, proves it with a unit test, runs the build + lint,
+and commits — all gated by `tool_build` and `tool_git`.
+
+> **You:** Now benchmark it against seqkit on the 10 GB test file.
+
+**Research OS** routes to `build/benchmark_vs_baseline`: runs both,
+captures wall-clock + peak memory + a diff proving identical dedup
+output, and writes the result into `eval/`. It reports: 2.7x faster,
+output identical. The acceptance criterion passes.
+
+> **You:** Cut a release.
+
+**Research OS** routes to `build/release_and_changelog`: tags the inner
+repo, writes the changelog entry, and confirms the eval + tests + build
+are all green.
+
+**Full walkthrough:** [TOOL_BUILDER.md](TOOL_BUILDER.md).
+
+---
+
+## Scenario 5 — Qualitative researcher with interview transcripts
+
+**Priya, health-services researcher.** She has 18 semi-structured
+interview transcripts about clinician burnout and needs to get from raw
+transcripts to a publishable qualitative paper — with the
+trustworthiness rigor reviewers in her field demand.
+
+```bash
+research-os init burnout-study --ide cursor
+cp ~/interviews/*.txt burnout-study/inputs/raw_data/
+cp ~/irb/interview_guide.pdf burnout-study/inputs/context/instruments/
+```
+
+> **You:** I have 18 interview transcripts in raw_data about clinician
+> burnout. Walk this through to a paper plus a dashboard.
+
+**Research OS** routes the chain: `methodology/qualitative_research`
+(open + axial coding, theme synthesis) →
+`methodology/coding_scheme_development` (hybrid codebook) →
+`methodology/qualitative_quality_audit`. That last one is the part that
+makes it publishable: it requires **saturation evidence** (not a power
+calc — qualitative sample size is justified by saturation, per Guest,
+Bunce & Johnson 2006), a reflexivity statement, intercoder agreement,
+member-checking notes, and quote anonymization.
+
+> **You:** Show me where saturation actually flattens.
+
+**Research OS** produces the saturation curve from
+`qualitative_quality_audit::saturation_evidence_check` — new codes per
+transcript, flattening around interview 14. That's the defensible "why
+18 was enough" answer.
+
+Then `audit/audit_and_validation` → `synthesis/synthesis_paper`
+(IMRAD-flavored, with anonymized quotes) →
+`synthesis/synthesis_dashboard` (a story-mode offline HTML she can email
+to her co-authors).
+
+**On disk:** `synthesis/paper.pdf` and `synthesis/dashboard.html` —
+single-file, opens offline, no server needed.
+
+---
+
+## Scenario 6 — Bringing a half-finished project into Research OS
+
+**Lin, applied-stats researcher.** She's been working in a messy folder
+for three months — scripts, figures, a half-written draft — before she
+ever heard of Research OS. She does *not* want to redo the intake or
+re-run everything.
+
+```bash
+research-os init . --ide claude    # init in the existing folder
+# her existing files are untouched; RO scaffolds around them
+```
+
+> **You:** I'm bringing this project into Research-OS. We've been at it
+> for months — there's a draft, some figures, and analysis scripts
+> already. Don't make me start over.
+
+**Research OS** routes to `guidance/mid_pipeline_entry`. Instead of
+forcing the 10-stage pipeline from stage 1, it inventories what already
+exists, asks where the real outputs live, and rebuilds the expected
+metadata from the files already present (via `tool_workspace_repair` if
+the layout is irregular).
+
+> **You:** We already have the results. Just help me write it up
+> properly and check the claims.
+
+**Research OS** routes to `synthesis/synthesis_from_inputs` — it drafts
+the paper from her existing results rather than re-deriving them, then
+`audit/pre_submission_checklist` flags two ungrounded claims and one
+figure missing a caption. She fixes the source; the gate goes GREEN.
+
+**The point:** Research OS meets you where you are. The pipeline is a
+default, not a toll booth.
+
+---
+
+## Scenario 7 — "I just need one good figure"
+
+**Tom, MD doing a quick analysis.** He has a results CSV and a poster
+session tomorrow. He does not want a project — he wants one
+publication-quality figure.
+
+```bash
+research-os init quick-fig --workspace-mode exploration --ide cursor
+cp ~/results.csv quick-fig/inputs/raw_data/
+```
+
+> **You:** build me a figure from results.csv — Kaplan-Meier by
+> treatment arm, colour-blind safe, 300 DPI.
+
+**Research OS** routes straight to `visualization/visualization_workflow`
+— no project pipeline. It pulls a color-blind-safe palette
+(`tool_figure_palette`, Okabe-Ito), writes the plotting script, renders
+at 300 DPI, and drops the figure with a `.caption.md` beside it.
+
+> **You:** Add risk tables under the curves and critique it like a
+> reviewer would.
+
+**Research OS** updates the figure, then routes
+`visualization/figure_critique` for a reviewer-style pass (legibility at
+poster distance, axis honesty, redundant encoding). Ten minutes, one
+figure, no ceremony.
+
+---
+
+## How these compose
+
+`tool_route` picks **one** protocol per message. A whole project is many
+protocols chained — Research OS walks the chain automatically as each
+protocol's `next_protocol` advances. The canonical end-to-end pipelines
+(qualitative study, ML benchmark, theory proof, humanities essay,
+tool-build) are tabulated in
+[USE_CASES.md § End-to-end recipes](USE_CASES.md#end-to-end-recipes-the-protocol-stack-for-a-complete-deliverable).
+
+If the router ever picks the wrong protocol, say *"actually I meant X"* —
+it re-routes without reloading your workspace.
+
+---
+
+## Where to go next
+
+- **Want the full role × goal × output map?** → [USE_CASES.md](USE_CASES.md)
+- **Want the day-to-day mechanics?** → [RESEARCHER_GUIDE.md](RESEARCHER_GUIDE.md)
+- **Installing for the first time?** → [START.md](START.md)
+- **Building a tool, not analyzing data?** → [TOOL_BUILDER.md](TOOL_BUILDER.md)
+- **Stuck?** → [FAQ.md](FAQ.md)

--- a/docs/START.md
+++ b/docs/START.md
@@ -50,7 +50,7 @@ Verify:
 
 ```bash
 research-os --help
-# Seven commands: init / ide / mcp / api-key / start / doctor / completion
+# Ten commands: init / ide / mcp / hermes / route / api-key / start / doctor / refresh / completion
 ```
 
 If `research-os: command not found`, add `~/.local/bin` (or your
@@ -372,7 +372,7 @@ After install + scaffold, your first prompt should be one of:
 
 ## Cheatsheet — every command worth knowing
 
-### CLI (seven commands)
+### CLI (ten commands)
 
 ```bash
 research-os init                          # scaffold THIS folder
@@ -392,6 +392,13 @@ research-os doctor --workspace-only       # skip install-side checks
 research-os start                         # run the MCP server (global)
                                           # you rarely run this by hand —
                                           # your IDE auto-launches it
+
+research-os hermes add                    # wire the Hermes agent (optional)
+research-os route "fit a survival model"  # preview which protocol the router picks
+research-os refresh                       # re-sync this project's template files
+                                          #   (AGENTS.md / CLAUDE.md / IDE rules)
+                                          #   after upgrading research-os
+research-os completion bash               # emit a shell-completion script
 ```
 
 ### Where files go

--- a/docs/START.md
+++ b/docs/START.md
@@ -152,7 +152,8 @@ careful collaborator, not an eager autocomplete:
 
 When you're ready for more, the [1-hour walkthrough](#the-1-hour-walkthrough-optional)
 below shows the full arc; [USE_CASES.md](USE_CASES.md) maps "what I want"
-to "what to say".
+to "what to say"; and [SCENARIOS.md](SCENARIOS.md) walks seven complete
+real projects from first prompt to finished `synthesis/` output.
 
 ---
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -124,6 +124,8 @@ hard-removed in v2.0.0 (Phase 14a) — they return a friendly
 | `tool_audit` | `scope` + `dimension` | step/project/synthesis × completeness, code_quality, prose, claims, citations, coherence, cross_deliverable, dashboard_content, evalue, figure, figure_coverage, figure_full, figure_interactivity, power, reproducibility, reviewer_responses, step_literature, version_coherence, cliches, all | `tool_audit_assumptions`, `tool_audit_citations`, `tool_audit_claims`, `tool_audit_cliches`, `tool_audit_code_quality`, `tool_audit_coherence`, `tool_audit_cross_deliverable_consistency`, `tool_audit_dashboard_content`, `tool_audit_evalue`, `tool_audit_figure`, `tool_audit_figure_coverage`, `tool_audit_figure_full`, `tool_audit_figure_interactivity`, `tool_audit_figure_quality`, `tool_audit_power`, `tool_audit_prose`, `tool_audit_reproducibility`, `tool_audit_reviewer_responses`, `tool_audit_statistical_power`, `tool_audit_step_completeness`, `tool_audit_step_literature`, `tool_audit_synthesis`, `tool_audit_version_coherence` |
 | `tool_audit_findings` | `operation` | `query` (filter the ledger), `diff` (compare two snapshots by stable id), `explain` (full chronological history + untruncated suggested_fix for one id — call after a synthesize BLOCK; the BLOCK envelope's `next_recommended_call` points at it) | `tool_audit_findings_query`, `tool_audit_findings_diff` |
 | `tool_audit_quality_full` | — (aggregator) | (standalone) — runs every gate in one call and returns structured per-component verdicts | — |
+| `tool_build` | `operation` | `build`, `test`, `lint` — shells the per-operation command declared in `researcher_config.yaml#workspace.commands.{build,test,lint}` with cwd = the `tool_build` inner repo. The build-mode counterpart of `tool_scratch`. | — |
+| `tool_git` | `operation` | `init`, `status`, `commit`, `branch`, `tag`, `log`, `diff` — provenance-aware git hard-scoped to the `tool_build` inner project repo (`workspace.inner_repo`, default `project`). | — |
 | `tool_data` | `operation` | `sample`, `profile`, `convert` (CSV ↔ Parquet ↔ Feather ↔ RDS) | `tool_data_sample`, `tool_data_profile`, `tool_data_convert` |
 | `tool_ground` | `mode` | `explicit` (register a decision↔evidence binding), `from_context` (extract bindings from a step's conclusions) | **removed**: `tool_grounding_register`, `tool_ground_from_context` |
 | `tool_lessons` | `operation` | `record`, `consult` (cross-session lesson store), `failure_record`, `failure_check`, `failure_list` (URL/DOI paywall / 404 memory), `dead_end` (dead-end summariser), `mistake_replay` (recurring-pattern coaching) | `tool_dead_end_lessons`, `tool_failure_record`, `tool_failure_check`, `tool_failure_list`, `tool_mistake_replay`; **removed**: `tool_lessons_record`, `tool_lessons_consult` |
@@ -154,13 +156,16 @@ hard-removed in v2.0.0 (Phase 14a) — they return a friendly
 | `tool_citations_verify` | Re-verify every `citation_key` in `workspace/citations.md`. |
 | `tool_context_intake` | Route a mid-flow file drop into the right `inputs/` subfolder. Skips scaffold files. |
 | `tool_cytoscape_export_static` | (adapter: `cytoscape`) Render a static PNG / SVG snapshot of one or every network embedded in a `.cys` archive. |
+| `tool_deliverable_chooser` | "I'm done, what now?" — inspects project readiness (steps with conclusions, figures, citations) + `researcher_config.yaml#research_goal.output_types` and recommends which deliverable(s) to build (asks if none declared). Surfaces always-available interim artifacts (e.g. step reports) without forcing them. |
 | `tool_deprecations_summary` | Listed above (Discovery). |
 | `tool_discussion_coverage_audit` | BLOCK gate: every non-AGREES literature verdict must have a Discussion paragraph. |
 | `tool_dry_run` | Listed above (Discovery). |
 | `tool_engineering_fault_tree_render` | (pack: `engineering`) Render a fault tree as Mermaid + optional SVG. |
 | `tool_engineering_fmea_render` | (pack: `engineering`) Render FMEA (Failure Mode & Effects Analysis) from YAML to CSV + Markdown (+ optional `.xlsx`). Computes RPN = severity × occurrence × detection. |
 | `tool_engineering_requirements_matrix` | (pack: `engineering`) Bidirectional requirements ↔ design elements ↔ test cases ↔ test results matrix. |
+| `tool_explain` | Plain-language tutor for any concept / method / topic. Returns a grounded, LAYERED explanation scaffold (intuition → mechanics → caveats), tuned to an optional `depth` — not a memorised answer. |
 | `tool_external_tool_instructions` | Writes a `WORKSHEET.md` when the chosen tool is external (website / paid / GUI). |
+| `tool_finalize_project` | Server-enforced ship gate. `operation='check'\|'finalize'` — the ONE gate that can actually REFUSE "done": aggregates BLOCK-severity findings (unresolved audit blockers, unverified citations, missing provenance) across the whole project. Every other gate is advisory. |
 | `tool_humanities_archive_lookup` | (pack: `humanities`) Query digital archives (Internet Archive / HathiTrust / DPLA / Europeana / Gallica / Library of Congress). |
 | `tool_humanities_citation_chain` | (pack: `humanities`) Chain-of-custody for a quotation: original ms → critical edition → translation → secondary citation. |
 | `tool_humanities_transcribe` | (pack: `humanities`) Scaffold OCR + manual-correction for an archival image. Side-by-side transcription template. |
@@ -206,6 +211,7 @@ hard-removed in v2.0.0 (Phase 14a) — they return a friendly
 | `tool_semantic_route` | Listed above (Discovery). |
 | `tool_session_resume` | Reconstruct intent + status from logs after any pause / handoff / new chat. |
 | `tool_synthesize_plan` | Inspect workspace + return what's ready to draft (per-section source paths + gaps). Read-only; call before authoring synthesis files. |
+| `tool_skills` | Self-improving skill registry. `operation='distill'\|'promote'\|'list'` — clusters this project's recorded lessons (`workspace/.lessons/lessons.jsonl`) by tag and crystallizes recurring patterns into reusable, Hermes-compatible `SKILL.md` cards. The self-improving loop on top of `tool_lessons`. |
 | `tool_slurm_estimate_cost` | (adapter: `slurm`) Estimate compute cost from `#SBATCH walltime + nodes × $/node-hour`. |
 | `tool_slurm_fetch` | (adapter: `slurm`) Block until a SLURM job finishes; return stdout / stderr paths. |
 | `tool_slurm_job_status` | (adapter: `slurm`) Query Slurm (`squeue --json`) or PBS (`qstat -f`) for a job's status. |
@@ -227,7 +233,9 @@ hard-removed in v2.0.0 (Phase 14a) — they return a friendly
 | `tool_tools_list` | Listed above (Discovery). |
 | `tool_web_scrape` | Scrape a URL to markdown. |
 | `tool_wet_lab_plate_map_render` | (pack: `wet_lab`) Render a 96- or 384-well plate layout as PNG / SVG from a YAML spec. |
+| `tool_wet_lab_checksum_raw` | (pack: `wet_lab`) Compute the SHA-256 + size of a raw instrument output file (never trust an operator-typed checksum) and, given `run_log_path`, append the `{path, sha256, size_bytes}` entry to that run log. Streams the file for large sequencer/imaging output. |
 | `tool_wet_lab_reagent_query` | (pack: `wet_lab`) Structured query plan + write-into-`reagents.yaml` stub for one reagent. |
+| `tool_wet_lab_run_log_init` | (pack: `wet_lab`) Stub a structured instrument run-log YAML for an instrument family at `workspace/<step>/runs/<family>_<run_label>.yaml`. Pre-fills the family-appropriate parameter fields + capture timestamp with TODO placeholders. |
 | `tool_wet_lab_sample_lineage_export` | (pack: `wet_lab`) Render the parent → split → aliquot → readout tree as JSON + Mermaid. |
 | `tool_workflow_dag` | Build a DAG of numbered steps + data dependencies; write `docs/workflow_dag.mermaid` (+ PNG if `mmdc` present). Auto-refreshed on path create/abandon. |
 | `tool_workspace_repair` | Detect missing dirs / corrupted state / stale paths and (optionally) heal. NEVER deletes. |

--- a/docs/USE_CASES.md
+++ b/docs/USE_CASES.md
@@ -7,6 +7,13 @@ your role, find your situation, see the protocol the AI will route to.
 You don't need to memorise this. Just talk in plain English; `tool_route`
 picks the protocol. This page exists so you know what's possible.
 
+> **Want to see it on a real project instead of a lookup table?**
+> [SCENARIOS.md](SCENARIOS.md) walks seven complete projects end-to-end —
+> a messy CSV to a paper, reproducing a published result, prepping an
+> R01, benchmarking your own tool, interview transcripts to publication —
+> with the exact prompts and what lands on disk. Read the one closest to
+> your situation, then come back here for the full map.
+
 ---
 
 ## Common first prompts (start here)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "research-os"
-version = "3.11.0"
+version = "3.11.1"
 description = "MCP server for reproducible, grounded, citation-verified research — sub-task pipelines, provenance sidecars, publication-grade visualisation, grounded reasoning, and self-tested dashboards."
 readme = "README.md"
 authors = [

--- a/src/research_os/__init__.py
+++ b/src/research_os/__init__.py
@@ -5,4 +5,4 @@ language, and get publication-grade analyses with provenance sidecars,
 plain-English captions, and a self-tested dashboard you can email.
 """
 
-__version__ = "3.11.0"
+__version__ = "3.11.1"


### PR DESCRIPTION
v3.11.1 — PATCH, docs-only. Two parts in one release:

1. **Accuracy pass** — audited the whole docs/ tree + README against the live registry/protocols/CLI (TOOLS.md +8 tools → all 152 covered, PROTOCOLS.md regenerated to 130/13, CLI.md 10 commands, AI_GUIDE/START fixes).
2. **Content overhaul** — new docs/SCENARIOS.md with 7 complete realistic end-to-end worked examples (named researcher, real data, exact prompts, what lands in synthesis/). Every protocol/tool/CLI flag referenced verified against the live registry. Refreshed FAQ lead-in (dropped stale v2.0.0-first framing), fixed the removed server.py reference, and fixed all cross-doc broken links (0 broken across docs/ + README).

Gate: preflight 33/33, ruff clean, 2334 passed / 13 skipped, 0 broken links.